### PR TITLE
release-app: gate App publishes on a clean, aligned source tree

### DIFF
--- a/scripts/release-app.mjs
+++ b/scripts/release-app.mjs
@@ -25,6 +25,11 @@ import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import {
+  assertPublishableAppReleaseSource,
+  readReleaseSourceState
+} from './release-source-state.mjs'
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 // Publishing coordinates live in scripts/r2.jsonc (see release-cli.mjs).
 const r2Config = readFileSync(resolve(repoRoot, 'scripts/r2.jsonc'), 'utf8')
@@ -37,7 +42,7 @@ for (let i = 2; i < argv.length; i += 1) {
   const arg = argv[i]
   if (!arg.startsWith('--')) throw new Error(`Unexpected argument: ${arg}`)
   const key = arg.slice(2)
-  if (key === 'dry-run' || key === 'skip-build') {
+  if (key === 'dry-run' || key === 'skip-build' || key === 'allow-dirty') {
     args[key] = true
   } else {
     args[key] = argv[++i]
@@ -61,6 +66,13 @@ if (!['alpha', 'beta', 'stable'].includes(channel)) {
 }
 const bucket = String(args.bucket ?? configBucket ?? 'unpeel-releases')
 const dryRun = Boolean(args['dry-run'])
+const allowDirty = Boolean(args['allow-dirty'])
+
+// Never upload protocol/app-registry.json (or any App artifact) from a dirty
+// or unaligned tree: a real publish reads the registry from the working tree,
+// so an uncommitted edit would ship silently. Same gate release-cli.mjs uses.
+const sourceState = readReleaseSourceState(repoRoot, { checkRemote: !dryRun })
+assertPublishableAppReleaseSource(sourceState, { dryRun, allowDirty })
 
 const manifest = readFileSync(resolve(designDir, 'Cargo.toml'), 'utf8')
 const version = String(

--- a/scripts/release-app.test.mjs
+++ b/scripts/release-app.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { assertPublishableAppReleaseSource } from './release-source-state.mjs'
+
+const commit = 'a'.repeat(40)
+const cleanMain = {
+  head: commit,
+  branch: 'main',
+  originMain: commit,
+  remoteMain: commit,
+  dirty: false,
+  dirtyEntries: []
+}
+const dirtyMain = {
+  ...cleanMain,
+  dirty: true,
+  dirtyEntries: [' M protocol/app-registry.json']
+}
+
+test('App publish refuses a dirty tree so the registry is never uploaded uncommitted', () => {
+  assert.throws(
+    () => assertPublishableAppReleaseSource(dirtyMain, { dryRun: false, allowDirty: false }),
+    /clean worktree/
+  )
+  // Also enforces branch/origin alignment, exactly like the CLI gate.
+  assert.throws(
+    () => assertPublishableAppReleaseSource({ ...cleanMain, branch: 'feature' }, {}),
+    /branch main/
+  )
+})
+
+test('App publish passes on a clean, aligned main', () => {
+  assert.doesNotThrow(() => assertPublishableAppReleaseSource(cleanMain, { dryRun: false, allowDirty: false }))
+})
+
+test('--dry-run is unaffected: a dirty tree still passes', () => {
+  assert.doesNotThrow(() => assertPublishableAppReleaseSource(dirtyMain, { dryRun: true }))
+})
+
+test('--allow-dirty is the explicit escape hatch for a dirty tree', () => {
+  assert.doesNotThrow(() => assertPublishableAppReleaseSource(dirtyMain, { allowDirty: true }))
+})

--- a/scripts/release-source-state.mjs
+++ b/scripts/release-source-state.mjs
@@ -70,6 +70,16 @@ export function assertPublishableReleaseSource(state) {
   }
 }
 
+/// The App-publish gate: real App publishes must run from a clean, aligned
+/// main so `protocol/app-registry.json` is uploaded from a committed tree,
+/// never with uncommitted working-tree edits. `dryRun` skips the check
+/// (rehearsals are unaffected) and an explicit `allowDirty` is the deliberate
+/// local-run escape hatch; both are ignored for a real publish otherwise.
+export function assertPublishableAppReleaseSource(state, { dryRun = false, allowDirty = false } = {}) {
+  if (dryRun || allowDirty) return
+  assertPublishableReleaseSource(state)
+}
+
 export function cliBuildProvenance({ state, version, target }) {
   return {
     schema: 1,


### PR DESCRIPTION
## What

`scripts/release-app.mjs` publishes App binaries and re-uploads
`protocol/app-registry.json` **from the working tree**, but unlike
`release-cli.mjs` it had no source-state gate. A real App publish could
therefore ship uncommitted registry edits silently.

This adds the same gate the CLI release uses:

- new `assertPublishableAppReleaseSource(state, { dryRun, allowDirty })` in
  `release-source-state.mjs`, composed from `assertPublishableReleaseSource`
  (branch `main`, clean worktree, `origin/main` aligned);
- `release-app.mjs` reads `readReleaseSourceState` and calls it right after
  arg parsing — **before the build and any upload**;
- `--dry-run` is unaffected (rehearsals still run against a dirty tree) and
  `--allow-dirty` is an explicit local-run escape hatch.

## Tests

`scripts/release-app.test.mjs` (state-based, matching the existing
`release-source-state` tests): dirty tree refused, off-`main` refused, clean
aligned `main` passes, `--dry-run` unaffected, `--allow-dirty` overrides.

- `bun run test:release` → 41 pass
- `node scripts/release-app.mjs --app markdown --channel stable --dry-run` →
  unaffected, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
