### PR TITLE
serve: reap leftover session hosts + per-workspace PATH cache (0.5.1)

### DIFF
--- a/crates/unpeel-cli/src/cli.rs
+++ b/crates/unpeel-cli/src/cli.rs
@@ -61,6 +61,7 @@ unpeel — run and steer CLI agent sessions
   unpeel add [PATH] [--name N] [--here] [--json]
                                   add a folder (default: here) as a project
   unpeel projects [list | add <name> <path> | remove <name|path>]
+  unpeel hosts prune [--json]    reap leftover hosts of filed sessions
   unpeel help
   unpeel --version
 ";
@@ -683,6 +684,51 @@ fn serve() -> Result<(), String> {
     })
 }
 
+const HOSTS_USAGE: &str = "usage: unpeel hosts prune [--json]
+
+Terminate leftover per-process session hosts in this workspace whose session
+is already filed (exited or archived) but whose host process never exited.
+Runs the same reap the Host service performs at startup and on a slow timer.
+Only a provably-identical recorded host process (pid + start time) is signaled,
+never the shared PTY core, never by name match. Prints what it reaped.";
+
+/// `unpeel hosts prune` — user-only on-demand reap of orphaned session hosts.
+fn hosts_prune(json: bool) -> Result<(), String> {
+    let reaped = unpeel_core::session_host::reap_orphan_session_hosts();
+    if json {
+        let rows: Vec<serde_json::Value> = reaped
+            .iter()
+            .map(|host| {
+                serde_json::json!({
+                    "session_id": host.session_id,
+                    "host_pid": host.host_pid,
+                    "reason": host.reason.as_str(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::Value::Array(rows));
+        return Ok(());
+    }
+    if reaped.is_empty() {
+        println!("no leftover session hosts to prune");
+    } else {
+        for host in &reaped {
+            println!(
+                "reaped session host pid {} ({} session {})",
+                host.host_pid,
+                host.reason.as_str(),
+                host.session_id
+            );
+        }
+        let count = reaped.len();
+        println!(
+            "pruned {count} leftover session host{}",
+            if count == 1 { "" } else { "s" }
+        );
+    }
+    Ok(())
+}
+
 const SERVE_USAGE: &str = "usage: unpeel serve [install [--graphical] | uninstall | status]
 
 Run the UI-free Host service for the default and registered workspaces until
@@ -901,6 +947,19 @@ pub fn run(args: &[String]) -> i32 {
             crate::workspaces::cli(&parsed.positional[1..], parsed.has("json")).map(|_| 0)
         }
         "profiles" | "profile" => Err("`profiles` was renamed; use `unpeel workspaces`".into()),
+        "hosts" => match args.get(1).map(String::as_str) {
+            Some("prune")
+                if parsed.positional.len() == 2
+                    && parsed.flags.keys().all(|flag| flag == "json") =>
+            {
+                hosts_prune(parsed.has("json")).map(|_| 0)
+            }
+            Some("--help" | "-h" | "help") if parsed.positional.len() == 2 => {
+                println!("{HOSTS_USAGE}");
+                Ok(0)
+            }
+            _ => Err(HOSTS_USAGE.into()),
+        },
         "projects" => projects(&args[1..]).map(|_| 0),
         "serve" => match args.get(1).map(String::as_str) {
             None => serve().map(|_| 0),

--- a/crates/unpeel-cli/tests/harness.py
+++ b/crates/unpeel-cli/tests/harness.py
@@ -205,6 +205,87 @@ def squeeze(text: str) -> str:
 # ─────────────────────────── fixture home ───────────────────────────
 
 
+# Leftover-process hygiene: a case must not leave `unpeel-host __session_host__`
+# or `__mcp__` sidecars running against its home. A leaked host keeps writing
+# to an unlinked output.bin (filling the disk) and re-runs the login-shell
+# PATH probe every tick (the load-average blowup). We detect them by open home
+# path so an untracked stray is caught, fail the case, then kill them so the
+# next case starts clean. The shared `__pty_core__` is NOT a leak here: it is
+# legitimate during a case and run.sh sweeps it by its lock file.
+def _pids_with_arg(arg):
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", arg], capture_output=True, text=True, check=False
+        ).stdout
+    except Exception:
+        return []
+    pids = []
+    for line in out.split():
+        try:
+            pids.append(int(line))
+        except ValueError:
+            pass
+    return pids
+
+
+def _process_references_home(pid, home_real):
+    # argv mentions the home (covers __session_host__ launch files)…
+    try:
+        cmd = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, check=False,
+        ).stdout
+        if home_real in cmd:
+            return True
+    except Exception:
+        pass
+    # …or its UNPEEL_HOME env points at the home (covers __mcp__ sidecars,
+    # which carry no home in argv)…
+    try:
+        env = subprocess.run(
+            ["ps", "eww", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, check=False,
+        ).stdout
+        if f"UNPEEL_HOME={home_real}" in env or f"UNPEEL_HOME={home_real}/" in env:
+            return True
+    except Exception:
+        pass
+    # …or it holds any file open under the home (covers a core by its lock).
+    try:
+        lsof = subprocess.run(
+            ["lsof", "-p", str(pid)], capture_output=True, text=True, check=False
+        ).stdout
+        for line in lsof.splitlines():
+            field = line.split()[-1] if line.split() else ""
+            if field.startswith(home_real + "/") or field == home_real:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def leftover_host_processes(home_root):
+    """(pid, command) for host/sidecar/core processes still bound to this home."""
+    home_real = os.path.realpath(home_root)
+    seen = set()
+    leftovers = []
+    # The shared __pty_core__ is a legitimate detached process during a case
+    # (core-hosted sessions run inside it) and run.sh sweeps it by its lock
+    # file; only stray per-process hosts and mcp sidecars are a leak here.
+    for arg in ("__session_host__", "__mcp__"):
+        for pid in _pids_with_arg(arg):
+            if pid in seen:
+                continue
+            if _process_references_home(pid, home_real):
+                seen.add(pid)
+                cmd = subprocess.run(
+                    ["ps", "-p", str(pid), "-o", "command="],
+                    capture_output=True, text=True, check=False,
+                ).stdout.strip()
+                leftovers.append((pid, cmd))
+    return leftovers
+
+
 class Home:
     """A private `~/.unpeel` built from scratch."""
 
@@ -1343,6 +1424,20 @@ class Case:
         subprocess.run(
             ["pkill", "-f", "dns-sd -R"], capture_output=True, check=False
         )
+        # After the case's own tracked cleanup, no host/sidecar/core may still
+        # be bound to this home. A stray one is a leak: fail the case, then
+        # kill it so it cannot poison the next case's home.
+        leftovers = leftover_host_processes(self.home.root)
+        self.check(
+            "no leftover session hosts / mcp sidecars under the home",
+            not leftovers,
+            "; ".join(f"pid {pid}: {cmd}" for pid, cmd in leftovers),
+        )
+        for pid, _cmd in leftovers:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
         failed = 0
         for name, passed, detail, elapsed in self.checks:
             suffix = f"  [{detail}]" if detail and not passed else ""

--- a/crates/unpeel-cli/tests/run.sh
+++ b/crates/unpeel-cli/tests/run.sh
@@ -115,6 +115,15 @@ for case_file in "$here"/cases/*.py; do
     | grep -F "$home/" \
     | awk '{print $1}' \
     | xargs -r kill -9 2>/dev/null || true
+  # `__mcp__` sidecars carry no home in argv (home is in their env), so match
+  # them by an open file under the home, the same way cores are found.
+  real="$(cd "$home" 2>/dev/null && pwd -P)" || real="$home"
+  for pid in $(pgrep -f "__mcp__" 2>/dev/null); do
+    if lsof -p "$pid" 2>/dev/null | awk -v a="$home/" -v b="$real/" \
+        '(index($NF, a) == 1 || index($NF, b) == 1) { found = 1 } END { exit(found ? 0 : 1) }'; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
   # A shared PTY core (`__pty_core__`) carries no home in its argv, but it
   # holds <home>/pty-core.lock open for its lifetime: sweep by that.
   sweep_cores_under "$home"

--- a/crates/unpeel-core/src/session_host.rs
+++ b/crates/unpeel-core/src/session_host.rs
@@ -4488,6 +4488,136 @@ pub(crate) fn mark_manifest_exited(session_id: &str) {
     });
 }
 
+/// Why a leftover per-process session host was reaped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReapReason {
+    /// The session's manifest is already `exited`.
+    Exited,
+    /// The session has been archived (an `archived.json` marker is present).
+    Archived,
+}
+
+impl ReapReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReapReason::Exited => "exited",
+            ReapReason::Archived => "archived",
+        }
+    }
+}
+
+/// A per-process `__session_host__` that was still running after its session
+/// was filed, and the reaper terminated it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReapedHost {
+    pub session_id: String,
+    pub host_pid: u32,
+    pub reason: ReapReason,
+}
+
+/// Terminate per-process session hosts that are STILL ALIVE even though their
+/// session is filed — manifest `exited`, or an `archived.json` marker present.
+///
+/// This is the leak behind the load-average blowup: a per-process host that
+/// never exited keeps running its observer / login-shell PATH-probe loop
+/// forever, one interactive shell per timer tick. `reap_dead_sessions` only
+/// normalizes *Running* manifests and garbage-collects dead *directories*; it
+/// never kills a live host whose session already finished. This does.
+///
+/// Kill discipline (mirrors `reap_dead_sessions`, never a name match):
+///   - only the additive `host_pid` is ever signaled — the `__session_host__`
+///     process, which `setsid`s at spawn, so `kill(-host_pid)` hits exactly
+///     that host's own process group (host + its PTY child), never the
+///     worker's;
+///   - only when `recorded_pid_identity(host_pid, host_pid_started_at)` is
+///     `Matches` (a recycled pid is `NotOurs`, an unverifiable one `Unknown` —
+///     both left untouched);
+///   - never the shared PTY core (`host_pid == core pid`, or an argv that
+///     mentions `__pty_core__`);
+///   - and only when the live argv actually contains `__session_host__`.
+///
+/// Returns what it reaped, newest logic first, for the trace log and the
+/// `unpeel hosts prune` verb. Safe to run repeatedly.
+pub fn reap_orphan_session_hosts() -> Vec<ReapedHost> {
+    let core_pid = crate::pty_core::load_record().map(|record| record.pid);
+    let mut reaped = Vec::new();
+
+    for manifest in list_manifests() {
+        let session_id = manifest.session.id.clone();
+
+        // Filed = the session is done and no host should still be running for
+        // it: an `exited` manifest, or an `archived.json` marker beside it
+        // (session_ops::ARCHIVE_MARKER; referenced by literal to avoid a
+        // session_ops -> session_host -> session_ops dependency cycle).
+        let archived = session_dir(&session_id).join("archived.json").exists();
+        let reason = match manifest.state {
+            HostedSessionState::Exited => ReapReason::Exited,
+            HostedSessionState::Running if archived => ReapReason::Archived,
+            _ => continue,
+        };
+
+        // Only modern per-process hosts recorded a host pid. Without one there
+        // is nothing safe to signal (the child shell pid is not the host).
+        let Some(host_pid) = manifest.host_pid else {
+            continue;
+        };
+        if host_pid <= 1 {
+            continue;
+        }
+        // Never signal the shared PTY core: it hosts many Sessions.
+        if Some(host_pid) == core_pid {
+            continue;
+        }
+        // Provably the same process we recorded, or leave it alone.
+        if recorded_pid_identity(host_pid, manifest.host_pid_started_at) != PidIdentity::Matches {
+            continue;
+        }
+        // Defense in depth against a pid recycled within tolerance onto the
+        // core or something unrelated: it must actually be a session host and
+        // must not be the core.
+        if process_argv_mentions(host_pid, SESSION_HOST_ARG) != Some(true) {
+            continue;
+        }
+        if process_argv_mentions(host_pid, crate::pty_core::PTY_CORE_ARG) == Some(true) {
+            continue;
+        }
+
+        // Signal both the process group (production hosts `setsid`, so
+        // `-host_pid` is their own group — never the worker's) and the pid
+        // itself (a host spawned without that pre_exec is not a group leader;
+        // a positive kill of a pid we just proved is ours is still safe). The
+        // group send is a harmless ESRCH when there is no such group. Mirrors
+        // the HostGuard reap in the process tests.
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(-(host_pid as i32), libc::SIGTERM);
+            libc::kill(host_pid as i32, libc::SIGTERM);
+        }
+        for _ in 0..20 {
+            thread::sleep(Duration::from_millis(100));
+            if !process_exists(host_pid) {
+                break;
+            }
+        }
+        #[cfg(unix)]
+        if process_exists(host_pid) {
+            unsafe {
+                libc::kill(-(host_pid as i32), libc::SIGKILL);
+                libc::kill(host_pid as i32, libc::SIGKILL);
+            }
+        }
+
+        mark_manifest_exited(&session_id);
+        reaped.push(ReapedHost {
+            session_id,
+            host_pid,
+            reason,
+        });
+    }
+
+    reaped
+}
+
 pub fn write_launch_file(launch: &SessionHostLaunch) -> Result<PathBuf, String> {
     ensure_session_dir(&launch.session.id)?;
     let path = launch_path(&launch.session.id);

--- a/crates/unpeel-core/src/setup.rs
+++ b/crates/unpeel-core/src/setup.rs
@@ -73,18 +73,91 @@ pub fn resolved_user_shell() -> String {
 /// new session's first PTY output, making heavy-startup agents (codex) appear
 /// to die instantly on launch. `OnceLock::get_or_init` also serializes racing
 /// callers to a single probe.
+/// How long a probed PATH is trusted across processes before a re-probe. The
+/// login shell's PATH barely changes; a workspace-wide cache means many hosts
+/// and observers share ONE probe per 10 minutes instead of each spawning
+/// `zsh -i` on its own timer — the interactive-shell storm that drove the load
+/// average to triple digits with leftover hosts.
+const PATH_CACHE_TTL_MS: u64 = 10 * 60 * 1000;
+
+fn path_cache_file() -> PathBuf {
+    crate::app_paths::unpeel_home().join("path-probe-cache.json")
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A fresh cached PATH for this workspace, or None when absent/stale/unreadable.
+fn read_cached_shell_path_dirs() -> Option<Vec<PathBuf>> {
+    let raw = std::fs::read(path_cache_file()).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    parse_cached_dirs(&value, now_unix_ms())
+}
+
+/// Pure cache-entry parse: `Some(dirs)` only when the entry carries a
+/// `probed_at_unix_ms` within the TTL of `now_ms`; stale or malformed → None.
+fn parse_cached_dirs(value: &serde_json::Value, now_ms: u64) -> Option<Vec<PathBuf>> {
+    let probed_at = value.get("probed_at_unix_ms").and_then(|v| v.as_u64())?;
+    if now_ms.saturating_sub(probed_at) >= PATH_CACHE_TTL_MS {
+        return None;
+    }
+    let dirs = value
+        .get("dirs")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str())
+        .map(PathBuf::from)
+        .collect();
+    Some(dirs)
+}
+
+/// Persist the probe result for the workspace. Empty results are cached too:
+/// the point is to throttle re-probes, and a leftover/misconfigured host that
+/// probes empty must not re-storm every tick. A best-effort atomic write.
+fn write_cached_shell_path_dirs(dirs: &[PathBuf]) {
+    let value = serde_json::json!({
+        "dirs": dirs.iter().map(|d| d.to_string_lossy()).collect::<Vec<_>>(),
+        "probed_at_unix_ms": now_unix_ms(),
+    });
+    let Ok(body) = serde_json::to_vec(&value) else {
+        return;
+    };
+    let path = path_cache_file();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, &body).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
 fn shell_path_dirs() -> Vec<PathBuf> {
+    // 1. Process-local: probe at most once per process (cheapest path).
     static CACHE: std::sync::OnceLock<Vec<PathBuf>> = std::sync::OnceLock::new();
     if let Some(dirs) = CACHE.get() {
         return dirs.clone();
     }
-    let dirs = probe_shell_path_dirs();
-    // A failed/empty probe must not poison the cache for the life of a
-    // long-running host; leave it uncached so the next call retries.
-    if dirs.is_empty() {
+    // 2. Workspace-wide disk cache shared across every host/observer process:
+    //    a fresh entry (probed < 10 min ago) is reused without spawning a
+    //    shell, so a fleet of hosts pays one probe per workspace per TTL.
+    if let Some(dirs) = read_cached_shell_path_dirs() {
+        if !dirs.is_empty() {
+            let _ = CACHE.set(dirs.clone());
+        }
         return dirs;
     }
-    CACHE.get_or_init(|| dirs).clone()
+    // 3. Miss/stale: probe once, then record it (even when empty) to throttle.
+    let dirs = probe_shell_path_dirs();
+    write_cached_shell_path_dirs(&dirs);
+    if !dirs.is_empty() {
+        let _ = CACHE.set(dirs.clone());
+    }
+    dirs
 }
 
 fn probe_shell_path_dirs() -> Vec<PathBuf> {
@@ -256,10 +329,44 @@ pub fn dependency_report() -> DependencyReport {
 #[cfg(test)]
 mod tests {
     use super::{
-        common_bin_dirs, extract_marked, find_command_path, platform_default_shell,
-        runtime_command_names,
+        common_bin_dirs, extract_marked, find_command_path, parse_cached_dirs,
+        platform_default_shell, runtime_command_names, PATH_CACHE_TTL_MS,
     };
     use std::path::PathBuf;
+
+    #[test]
+    fn path_cache_entry_is_reused_while_fresh_and_dropped_when_stale() {
+        let now = 1_000_000_000u64;
+        let fresh = serde_json::json!({
+            "dirs": ["/opt/homebrew/bin", "/usr/bin"],
+            "probed_at_unix_ms": now - 1_000,
+        });
+        assert_eq!(
+            parse_cached_dirs(&fresh, now),
+            Some(vec![
+                PathBuf::from("/opt/homebrew/bin"),
+                PathBuf::from("/usr/bin")
+            ])
+        );
+        // Exactly at the TTL boundary and beyond it is stale (re-probe).
+        let stale = serde_json::json!({
+            "dirs": ["/usr/bin"],
+            "probed_at_unix_ms": now - PATH_CACHE_TTL_MS,
+        });
+        assert_eq!(parse_cached_dirs(&stale, now), None);
+        // An empty-but-fresh entry is honored (it throttles a re-probe storm).
+        let empty_fresh = serde_json::json!({ "dirs": [], "probed_at_unix_ms": now });
+        assert_eq!(parse_cached_dirs(&empty_fresh, now), Some(Vec::new()));
+        // Malformed entries never parse.
+        assert_eq!(
+            parse_cached_dirs(&serde_json::json!({ "dirs": ["/x"] }), now),
+            None
+        );
+        assert_eq!(
+            parse_cached_dirs(&serde_json::json!({ "probed_at_unix_ms": now }), now),
+            None
+        );
+    }
 
     #[test]
     fn extract_marked_handles_shell_noise() {

--- a/crates/unpeel-host/tests/reap_orphan_hosts_process.rs
+++ b/crates/unpeel-host/tests/reap_orphan_hosts_process.rs
@@ -1,0 +1,164 @@
+#![cfg(unix)]
+
+//! The serve worker's orphan-host reaper (unpeel_core::session_host::
+//! reap_orphan_session_hosts): a per-process `__session_host__` still running
+//! after its session is filed is terminated, and a running one is left alone.
+//!
+//! One `#[test]` on purpose: it sets this process's own `UNPEEL_HOME` (the
+//! reaper reads it), so a second test in the same binary would race the env.
+
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn temp_home(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    PathBuf::from("/tmp").join(format!("u-reap-{label}-{}-{nonce:x}", std::process::id()))
+}
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+fn write_launch(home: &Path, session_id: &str, command: &str) -> PathBuf {
+    let session_dir = home.join("app-sessions").join(session_id);
+    fs::create_dir_all(&session_dir).unwrap();
+    let path = session_dir.join("launch.json");
+    fs::write(
+        &path,
+        serde_json::to_vec(&json!({
+            "session": {
+                "id": session_id, "project_id": "project", "label": command,
+                "custom_title": false, "command": command, "created_at": 1
+            },
+            "cwd": "/tmp", "dark_mode": true, "hook_port": null,
+            "mcp_enabled": false, "browser_mcp_enabled": false,
+            "computer_mcp_enabled": false, "initial_cols": 80, "initial_rows": 24
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    path
+}
+
+fn spawn_host(home: &Path, launch: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_unpeel-host"))
+        .arg("__session_host__")
+        .arg(launch)
+        .env("UNPEEL_HOME", home)
+        .env("HOME", home)
+        .env("SHELL", "/bin/bash")
+        .env("UNPEEL_PTY_CORE", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap()
+}
+
+fn manifest(home: &Path, id: &str) -> Option<Value> {
+    let raw = fs::read(home.join("app-sessions").join(id).join("manifest.json")).ok()?;
+    serde_json::from_slice(&raw).ok()
+}
+
+fn host_pid(home: &Path, id: &str) -> Option<u32> {
+    manifest(home, id)?
+        .get("host_pid")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+}
+
+fn alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[test]
+fn reaps_a_filed_host_and_leaves_a_running_one() {
+    let home = temp_home("mix");
+    fs::create_dir_all(home.join("app-sessions")).unwrap();
+    // The reaper reads UNPEEL_HOME from this process.
+    std::env::set_var("UNPEEL_HOME", &home);
+    std::env::set_var("UNPEEL_PTY_CORE", "0");
+
+    let filed_launch = write_launch(&home, "filed", "sleep 600");
+    let mut filed_host = spawn_host(&home, &filed_launch);
+    let running_launch = write_launch(&home, "running", "sleep 600");
+    let mut running_host = spawn_host(&home, &running_launch);
+
+    // Both hosts record their host_pid and come up running.
+    assert!(
+        wait_until(Duration::from_secs(30), || host_pid(&home, "filed")
+            .is_some()
+            && host_pid(&home, "running").is_some()),
+        "hosts never recorded host_pid: {:?} / {:?}",
+        manifest(&home, "filed"),
+        manifest(&home, "running")
+    );
+    let filed_pid = host_pid(&home, "filed").unwrap();
+    let running_pid = host_pid(&home, "running").unwrap();
+    assert!(
+        alive(filed_pid) && alive(running_pid),
+        "hosts should be alive"
+    );
+
+    // File the first session while its host keeps running: drop an
+    // `archived.json` marker beside it. (The manifest state is left to the
+    // live host — it heartbeats `running` continuously, so editing state here
+    // would just be overwritten; the archived marker is the stable "filed"
+    // signal the reaper also acts on, and the host never clears it.)
+    fs::write(
+        home.join("app-sessions")
+            .join("filed")
+            .join("archived.json"),
+        b"{\"archived_at\":1}",
+    )
+    .unwrap();
+
+    let reaped = unpeel_core::session_host::reap_orphan_session_hosts();
+
+    assert!(
+        reaped
+            .iter()
+            .any(|r| r.session_id == "filed" && r.host_pid == filed_pid),
+        "the filed session's host was not reaped: {reaped:?}"
+    );
+    // The reaper SIGKILLed the host; reap the zombie so kill(pid, 0) stops
+    // reporting the defunct entry as alive.
+    let _ = filed_host.wait();
+    assert!(
+        wait_until(Duration::from_secs(10), || !alive(filed_pid)),
+        "the filed host {filed_pid} is still alive after the reap"
+    );
+    // The running session is untouched: not reaped, still alive, still running.
+    assert!(
+        !reaped.iter().any(|r| r.session_id == "running"),
+        "a running session must not be reaped: {reaped:?}"
+    );
+    assert!(alive(running_pid), "the running host must stay alive");
+    assert_eq!(
+        manifest(&home, "running")
+            .and_then(|m| m.get("state").and_then(|s| s.as_str()).map(String::from)),
+        Some("running".to_string())
+    );
+
+    // Cleanup: stop the running host and reap the (already-dead) filed child.
+    unsafe {
+        libc::kill(-(running_pid as i32), libc::SIGKILL);
+        libc::kill(running_pid as i32, libc::SIGKILL);
+    }
+    let _ = running_host.wait();
+    let _ = filed_host.wait();
+    let _ = fs::remove_dir_all(&home);
+}

--- a/crates/unpeel-serve/src/driver.rs
+++ b/crates/unpeel-serve/src/driver.rs
@@ -33,6 +33,10 @@ const NATIVE_PROBE_INTERVAL: Duration = Duration::from_secs(1);
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(600);
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const LINK_RETRY_DELAY: Duration = Duration::from_secs(60);
+/// How often the worker sweeps leftover per-process session hosts whose
+/// session is already filed (see reap_orphan_session_hosts). Kept slow: the
+/// first sweep runs at startup, and steady state has nothing to reap.
+const REAP_INTERVAL: Duration = Duration::from_secs(60);
 const LINK_REJECTED_RETRY_DELAY: Duration = Duration::from_secs(15 * 60);
 const STATUS_VERSION: u64 = 1;
 
@@ -654,6 +658,10 @@ pub struct HostRuntime {
     link_refresh_rx: Option<mpsc::Receiver<LinkRefreshResult>>,
     link_refresh_retry_at: Instant,
     last_scan: Instant,
+    last_reap: Instant,
+    /// Set while a background reaper thread is running, so a slow sweep never
+    /// stacks another on the next tick.
+    reap_in_flight: Arc<AtomicBool>,
     status_dirty: bool,
 }
 
@@ -769,6 +777,8 @@ impl HostRuntime {
             link_refresh_rx: None,
             link_refresh_retry_at: Instant::now(),
             last_scan: Instant::now() - RESCAN_INTERVAL,
+            last_reap: Instant::now() - REAP_INTERVAL,
+            reap_in_flight: Arc::new(AtomicBool::new(false)),
             status_dirty: true,
         };
         let mut emitted = vec![
@@ -886,6 +896,10 @@ impl HostRuntime {
         self.reconcile_link(&mut emitted);
         self.supervise_streamer(&mut emitted);
         self.supervise_pty_core(&mut emitted);
+        if self.last_reap.elapsed() >= REAP_INTERVAL {
+            self.last_reap = Instant::now();
+            self.spawn_reap();
+        }
         if self.status_dirty {
             if let Err(error) = self.publish_status() {
                 emitted.push(ServeEvent::Warning(error));
@@ -1333,6 +1347,35 @@ impl HostRuntime {
 
     /// Every tick: step the PTY core supervisor and republish `serve.json`
     /// when its published state moves. The supervisor never stops a core.
+    /// Reap leftover per-process session hosts on a background thread. The
+    /// kill path waits up to ~2s per orphan, so it must never run inline in
+    /// the worker tick; `reap_in_flight` keeps at most one sweep going.
+    fn spawn_reap(&self) {
+        if self.reap_in_flight.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let flag = Arc::clone(&self.reap_in_flight);
+        let spawned = std::thread::Builder::new()
+            .name("unpeel-host-reaper".into())
+            .spawn(move || {
+                for reaped in unpeel_core::session_host::reap_orphan_session_hosts() {
+                    crate::tracelog::trace(
+                        "reaper",
+                        &format!(
+                            "terminated leftover session host pid {} ({} session {})",
+                            reaped.host_pid,
+                            reaped.reason.as_str(),
+                            reaped.session_id
+                        ),
+                    );
+                }
+                flag.store(false, Ordering::SeqCst);
+            });
+        if spawned.is_err() {
+            self.reap_in_flight.store(false, Ordering::SeqCst);
+        }
+    }
+
     fn supervise_pty_core(&mut self, emitted: &mut Vec<ServeEvent>) {
         for event in self.pty_core.poll() {
             emitted.push(ServeEvent::PtyCore(event));


### PR DESCRIPTION
## Why

Leftover `unpeel-host __session_host__` processes accumulated across upgrades
(some 25 days old, pre-PTY-core) and, because a failed/empty login-shell PATH
probe was never memoized, each re-ran `zsh -i` on every observer tick — a
per-tick interactive-shell storm that drove the load average into triple
digits and stalled the worker's platform-adapter and relay calls (3–8 s).

## What

1. **Reaper** — `session_host::reap_orphan_session_hosts` terminates
   per-process hosts still alive after their session is filed (manifest
   `exited`, or an `archived.json` marker). Kill discipline, never a name
   match: only the additive `host_pid` (the `__session_host__`, not the child
   shell) is signaled, only on `recorded_pid_identity == Matches` (recycled or
   unverifiable pids left untouched), never the shared PTY core, only when the
   argv is actually `__session_host__`. The serve worker runs it at startup
   and on a 60 s background tick (`reap_in_flight`-bounded, never inline).

2. **Per-workspace PATH cache** — `setup::shell_path_dirs` consults a
   `path-probe-cache.json` (10-min TTL) shared across all hosts/observers, so
   a fleet pays one probe per workspace per TTL instead of one `zsh -i` per
   tick per process. Empty results are cached too, to throttle the re-probe
   storm. The interactive probe is kept (it captures version-manager PATH that
   `-lc` misses); the cache — not the shell flag — is the storm fix.

3. **Test hygiene** — the PTY matrix harness (`harness.py` + `run.sh`) sweeps
   leftover `__session_host__` / `__mcp__` sidecars by open home path at case
   end and **fails the case** if any remain. The shared `__pty_core__` is
   legitimate mid-case and stays swept by its lock file.

4. **Verb** — `unpeel hosts prune` (user-only) runs the reaper on demand and
   prints what it reaped (`--json` supported).

## Tests / gates

- New process test `reap_orphan_hosts_process.rs`: a filed host is reaped, a
  running one is left alone.
- `setup.rs` cache-parse TTL unit test.
- `cargo fmt --all --check`; the three `linux-cli.yml` clippy jobs; `cargo
  test --workspace` (green); `bun run test:release` 41/41; matrix subset
  (standalone, mobile, cli, pty_core_parity, pairing) 127/0 with the new
  hygiene check active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
