### PR TITLE
serve: keep unit-test trace lines out of the real ~/.unpeel (0.5.1)

### DIFF
--- a/crates/unpeel-serve/src/tracelog.rs
+++ b/crates/unpeel-serve/src/tracelog.rs
@@ -4,11 +4,21 @@
 //! time); every serve trace line now carries UTC time + unix seconds.
 
 pub(crate) fn trace(component: &str, message: &str) {
+    let line = format!("{} {component} {message}", stamp());
     // This is also the only output channel for the app-launched service,
     // whose stdout/stderr are intentionally disconnected. Reuse the core
     // trace writer so diagnostics are directory-safe and bounded at 10 MiB
     // with one rotated `trace.log.1` generation.
-    unpeel_core::hook_assets::append_trace_log_line(&format!("{} {component} {message}", stamp()));
+    #[cfg(not(test))]
+    unpeel_core::hook_assets::append_trace_log_line(&line);
+    // Unit tests run with the developer's real `UNPEEL_HOME` (unset), so the
+    // fake platform adapters and relay-recovery replays used to append their
+    // lines to the operator's own `~/.unpeel/hooks/trace.log` (seen 2026-09-04).
+    // Every unit test in this crate shares one per-process scratch trace log
+    // instead; process cases set an isolated `UNPEEL_HOME` and keep the real
+    // writer above.
+    #[cfg(test)]
+    test_sink::append(&line);
 }
 
 fn stamp() -> String {
@@ -23,4 +33,31 @@ fn stamp() -> String {
         (seconds_of_day % 3600) / 60,
         seconds_of_day % 60
     )
+}
+
+#[cfg(test)]
+mod test_sink {
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::sync::OnceLock;
+
+    fn path() -> &'static PathBuf {
+        static PATH: OnceLock<PathBuf> = OnceLock::new();
+        PATH.get_or_init(|| {
+            let dir = std::env::temp_dir()
+                .join(format!("unpeel-serve-unit-trace-{}", std::process::id()));
+            let _ = std::fs::create_dir_all(&dir);
+            dir.join("trace.log")
+        })
+    }
+
+    pub(super) fn append(line: &str) {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path())
+        {
+            let _ = writeln!(file, "{line}");
+        }
+    }
 }


### PR DESCRIPTION
Follow-up from the PR #3 review: the serve crate's unit tests appended their fake-adapter and relay-recovery trace lines to the developer's real `~/.unpeel/hooks/trace.log` (no `UNPEEL_HOME` in unit tests). `tracelog::trace` is the only serve-side writer, so under `cfg(test)` it now writes to one per-process scratch log in the temp dir; process cases keep the real writer with their isolated `UNPEEL_HOME`.

Checked: the mobile tests already write their port files to explicit temp dirs, so the trace log was the only real-home side effect. 127 lib tests pass; the real trace.log line count is unchanged across a run; fmt + clippy (tests, -D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)