### PR TITLE
serve: drain an older-build PTY core instead of taking it over in place (0.5.2)

### DIFF
--- a/crates/unpeel-cli/src/cli.rs
+++ b/crates/unpeel-cli/src/cli.rs
@@ -227,7 +227,26 @@ fn print_sessions(args: &Args) {
     }
 }
 
+const NEW_USAGE: &str = "usage: unpeel new [--command C | --preset LABEL] [--cwd DIR] [--project ID] [--cols N] [--rows N] [--json]
+
+Create a new Session in this workspace. With no --command or --preset, opens a
+plain terminal. Prints the new session id (or {\"id\":...} with --json).";
+
 fn new_session(args: &Args) -> Result<(), String> {
+    // `--help`/`-h`/`help` must print usage and create nothing. Without this
+    // guard `unpeel new --help` fell through to "plain terminal" and spawned a
+    // stray Session (the 0.4-era hazard; regressed on old CLIs probed by the
+    // upgrade harness).
+    if args.has("help")
+        || args
+            .positional
+            .iter()
+            .skip(1)
+            .any(|arg| arg == "-h" || arg == "help")
+    {
+        println!("{NEW_USAGE}");
+        return Ok(());
+    }
     let command = match (args.value("preset"), args.value("command")) {
         (Some(label), _) => {
             let overlay = unpeel_serve::overlay::load();

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -439,9 +439,17 @@ def body(case):
     case.check("the older core's own session still echoes", wait_for(lambda: screen(home, drain_session).count("drain-core-text") >= 2))
 
     run_cli(home, ["rm", drain_session], timeout=45)
+
+    def replaced():
+        # The drained core is this test's child: reap it as soon as it exits,
+        # or its zombie keeps the pid alive and the supervisor cannot prove
+        # it gone (in production the core is detached and launchd reaps it).
+        drain_core.poll()
+        return serve_json().get("ptyCore", {}).get("state") == "live" and record_pid() not in (None, drain_core.pid)
+
     case.check(
         "once empty, the older core exits and a current-build core takes its place",
-        wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "live" and record_pid() not in (None, drain_core.pid), timeout=45),
+        wait_for(replaced, timeout=45),
         f"ptyCore={serve_json().get('ptyCore')} record_pid={record_pid()} trace={core_trace()}",
     )
     try:

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -312,7 +312,7 @@ def body(case):
     time.sleep(1.0)
     stale_screen = screen(home, stale_session)
 
-    serve = case.serve(env={"UNPEEL_PTY_CORE": "1"})
+    serve = case.serve(env={"UNPEEL_PTY_CORE": "1", "UNPEEL_PTY_CORE_TAKEOVER": "1"})
     serve.ready()
 
     def serve_json():
@@ -349,6 +349,72 @@ def body(case):
         f"state={home.manifests().get(stale_session, {}).get('state')} before={stale_screen[-160:]!r} after={screen(home, stale_session)[-160:]!r}",
     )
     run_cli(home, ["rm", stale_session], timeout=45)
+    serve.close()
+
+    # Default policy since 0.5.2 (no UNPEEL_PTY_CORE_TAKEOVER): the supervisor
+    # never takes an older-build core over in place. It keeps serving its
+    # Sessions, new Sessions run one process each, and once it is empty it is
+    # asked to exit so a current-build core starts.
+    core_request(home, {"op": "shutdown"})
+    time.sleep(1.0)
+    drain_core = start_core(home, binary=stale_bin)
+    stopper.cores.append(drain_core)
+    case.check("a second stale-build core is up", drain_core.poll() is None and core_record(home)["pid"] == drain_core.pid)
+    drain_session = new_session(case, home, "session under the draining core")
+    run_cli(home, ["send", drain_session, "drain-core-text", "--enter"])
+    case.check("the draining core's session echoes", wait_for(lambda: screen(home, drain_session).count("drain-core-text") >= 2))
+
+    serve = case.serve(env={"UNPEEL_PTY_CORE": "1"})
+    serve.ready()
+    case.check(
+        "serve adopts the stale-build core without taking it over",
+        wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "adopted", timeout=30),
+        str(serve_json().get("ptyCore")),
+    )
+    time.sleep(3.0)
+    case.check(
+        "no takeover is started while the older core holds Sessions",
+        serve_json().get("ptyCore", {}).get("state") == "adopted" and core_record(home)["pid"] == drain_core.pid,
+        str(serve_json().get("ptyCore")),
+    )
+    fresh_session = new_session(case, home, "session spawned while the older core drains")
+    run_cli(home, ["send", fresh_session, "one-process-text", "--enter"])
+    case.check(
+        "a new Session spawned meanwhile runs one process each, not in the older core",
+        wait_for(lambda: screen(home, fresh_session).count("one-process-text") >= 2)
+        and home.manifests().get(fresh_session, {}).get("host_pid") != drain_core.pid,
+        f"host_pid={home.manifests().get(fresh_session, {}).get('host_pid')} core={drain_core.pid}",
+    )
+    time.sleep(6.0)
+    case.check(
+        "that Session is still running six seconds later and its exit is not pending",
+        home.manifests().get(fresh_session, {}).get("state") == "running",
+        str(home.manifests().get(fresh_session, {}).get("state")),
+    )
+    case.check("the older core's own session still echoes", wait_for(lambda: screen(home, drain_session).count("drain-core-text") >= 2))
+
+    run_cli(home, ["rm", drain_session], timeout=45)
+    case.check(
+        "once empty, the older core exits and a current-build core takes its place",
+        wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "live" and core_record(home)["pid"] != drain_core.pid, timeout=45),
+        f"ptyCore={serve_json().get('ptyCore')} record={core_record(home)}",
+    )
+    try:
+        drain_core.wait(timeout=20)
+        drained_exit = drain_core.returncode
+    except subprocess.TimeoutExpired:
+        drained_exit = None
+    case.check("the drained core exited 0", drained_exit == 0, str(drained_exit))
+    after_session = new_session(case, home, "session in the current-build core")
+    run_cli(home, ["send", after_session, "fresh-core-text", "--enter"])
+    case.check(
+        "a Session created afterwards lands in the current-build core and runs",
+        wait_for(lambda: screen(home, after_session).count("fresh-core-text") >= 2)
+        and home.manifests().get(after_session, {}).get("host_pid") == core_record(home)["pid"],
+        f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={core_record(home)['pid']}",
+    )
+    for session_id in (fresh_session, after_session):
+        run_cli(home, ["rm", session_id], timeout=45)
     serve.close()
 
 

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -124,8 +124,8 @@ class StreamClient:
             pass
 
 
-def new_session(case, home, label, preset="cat"):
-    started = run_cli(home, ["new", "--preset", preset, "--project", "p"], timeout=45)
+def new_session(case, home, label, preset="cat", env=None):
+    started = run_cli(home, ["new", "--preset", preset, "--project", "p"], timeout=45, env=env)
     session_id = ""
     for token in started.stdout.split():
         if len(token) == 36 and token.count("-") == 4:
@@ -368,7 +368,14 @@ def body(case):
     drain_core = start_core(home, binary=stale_bin)
     stopper.cores.append(drain_core)
     case.check("a second stale-build core is up", drain_core.poll() is None and core_record(home)["pid"] == drain_core.pid)
-    drain_session = new_session(case, home, "session under the draining core")
+    # Spawn routing refuses a core built from another binary, so place this
+    # Session in the stale core by launching as that binary's own build.
+    drain_session = new_session(case, home, "session under the draining core", env={"UNPEEL_HOST_CMD": stale_bin})
+    case.check(
+        "that Session lives in the stale core",
+        home.manifests().get(drain_session, {}).get("host_pid") == drain_core.pid,
+        f"host_pid={home.manifests().get(drain_session, {}).get('host_pid')} core={drain_core.pid}",
+    )
     run_cli(home, ["send", drain_session, "drain-core-text", "--enter"])
     case.check("the draining core's session echoes", wait_for(lambda: screen(home, drain_session).count("drain-core-text") >= 2))
 

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -323,7 +323,12 @@ def body(case):
     stopper.cores.append(stale_core)
     stale_record = core_record(home)
     case.check("a core from the stale binary is up", stale_core.poll() is None and stale_record["pid"] == stale_core.pid)
-    stale_session = new_session(case, home, "session under the stale core")
+    stale_session = new_session(case, home, "session under the stale core", env={"UNPEEL_HOST_CMD": stale_bin})
+    case.check(
+        "that Session lives in the stale core",
+        home.manifests().get(stale_session, {}).get("host_pid") == stale_core.pid,
+        f"host_pid={home.manifests().get(stale_session, {}).get('host_pid')} core={stale_core.pid}",
+    )
     run_cli(home, ["send", stale_session, "stale-core-text", "--enter"])
     case.check("the stale core's session echoes", wait_for(lambda: screen(home, stale_session).count("stale-core-text") >= 2))
     time.sleep(1.0)

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -16,9 +16,26 @@ import threading
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from harness import BINARY, CRATES, run, run_cli, wait_running  # noqa: E402
+from harness import (  # noqa: E402
+    BINARY,
+    CRATES,
+    leftover_host_processes,
+    run,
+    run_cli,
+    wait_running,
+)
 
 HOST_BIN = os.path.join(CRATES, "target", "debug", "unpeel-host")
+
+
+def pid_is_zombie(pid):
+    """True while `pid` is an unreaped <defunct> child. A reaped child is
+    gone entirely (empty STAT); a leaked one shows STAT 'Z'."""
+    stat = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip()
+    return "Z" in stat
 
 
 def core_request(home, request, timeout=12.0):
@@ -428,8 +445,27 @@ def body(case):
         and home.manifests().get(after_session, {}).get("host_pid") == record_pid(),
         f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={record_pid()}",
     )
+    # 0.5.2 regression guard for the load-storm P0: a Session that exits on a
+    # core reached through the drain->fresh-core path must be REAPED — no
+    # <defunct> zombie child, no leftover per-process host. The wild failure
+    # was new spawns dying at exec and their shells never being waited on.
+    exiting_children = {
+        session_id: home.manifests()[session_id]["pid"]
+        for session_id in (fresh_session, after_session)
+    }
     for session_id in (fresh_session, after_session):
         run_cli(home, ["rm", session_id], timeout=45)
+    for session_id, child in exiting_children.items():
+        case.check(
+            f"{session_id[:8]} exit is reaped (no zombie child) after the drain",
+            wait_for(lambda child=child: not pid_is_zombie(child), timeout=15),
+            f"child {child} STAT still a zombie",
+        )
+    case.check(
+        "no leftover per-process host survives the drain-and-reap",
+        wait_for(lambda: not leftover_host_processes(home.root), timeout=15),
+        str(leftover_host_processes(home.root)),
+    )
     serve.close()
 
 

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -351,6 +351,14 @@ def body(case):
     run_cli(home, ["rm", stale_session], timeout=45)
     serve.close()
 
+    # The record disappears between the drained core's exit and the fresh core's
+    # start; read it leniently while waiting on that transition.
+    def record_pid():
+        try:
+            return core_record(home).get("pid")
+        except (FileNotFoundError, ValueError):
+            return None
+
     # Default policy since 0.5.2 (no UNPEEL_PTY_CORE_TAKEOVER): the supervisor
     # never takes an older-build core over in place. It keeps serving its
     # Sessions, new Sessions run one process each, and once it is empty it is
@@ -374,7 +382,7 @@ def body(case):
     time.sleep(3.0)
     case.check(
         "no takeover is started while the older core holds Sessions",
-        serve_json().get("ptyCore", {}).get("state") == "adopted" and core_record(home)["pid"] == drain_core.pid,
+        serve_json().get("ptyCore", {}).get("state") == "adopted" and record_pid() == drain_core.pid,
         str(serve_json().get("ptyCore")),
     )
     fresh_session = new_session(case, home, "session spawned while the older core drains")
@@ -396,8 +404,8 @@ def body(case):
     run_cli(home, ["rm", drain_session], timeout=45)
     case.check(
         "once empty, the older core exits and a current-build core takes its place",
-        wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "live" and core_record(home)["pid"] != drain_core.pid, timeout=45),
-        f"ptyCore={serve_json().get('ptyCore')} record={core_record(home)}",
+        wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "live" and record_pid() not in (None, drain_core.pid), timeout=45),
+        f"ptyCore={serve_json().get('ptyCore')} record_pid={record_pid()}",
     )
     try:
         drain_core.wait(timeout=20)
@@ -410,8 +418,8 @@ def body(case):
     case.check(
         "a Session created afterwards lands in the current-build core and runs",
         wait_for(lambda: screen(home, after_session).count("fresh-core-text") >= 2)
-        and home.manifests().get(after_session, {}).get("host_pid") == core_record(home)["pid"],
-        f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={core_record(home)['pid']}",
+        and home.manifests().get(after_session, {}).get("host_pid") == record_pid(),
+        f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={record_pid()}",
     )
     for session_id in (fresh_session, after_session):
         run_cli(home, ["rm", session_id], timeout=45)

--- a/crates/unpeel-cli/tests/cases/pty_core_handoff.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_handoff.py
@@ -381,7 +381,15 @@ def body(case):
         except (FileNotFoundError, ValueError):
             return None
 
-    # Default policy since 0.5.2 (no UNPEEL_PTY_CORE_TAKEOVER): the supervisor
+    def core_trace():
+        try:
+            with open(home.path("hooks", "trace.log"), errors="replace") as handle:
+                lines = [l.strip()[-150:] for l in handle if "PTY core" in l or "pty-core" in l]
+            return " || ".join(lines[-10:])
+        except FileNotFoundError:
+            return "(no trace)"
+
+        # Default policy since 0.5.2 (no UNPEEL_PTY_CORE_TAKEOVER): the supervisor
     # never takes an older-build core over in place. It keeps serving its
     # Sessions, new Sessions run one process each, and once it is empty it is
     # asked to exit so a current-build core starts.
@@ -434,7 +442,7 @@ def body(case):
     case.check(
         "once empty, the older core exits and a current-build core takes its place",
         wait_for(lambda: serve_json().get("ptyCore", {}).get("state") == "live" and record_pid() not in (None, drain_core.pid), timeout=45),
-        f"ptyCore={serve_json().get('ptyCore')} record_pid={record_pid()}",
+        f"ptyCore={serve_json().get('ptyCore')} record_pid={record_pid()} trace={core_trace()}",
     )
     try:
         drain_core.wait(timeout=20)
@@ -448,7 +456,7 @@ def body(case):
         "a Session created afterwards lands in the current-build core and runs",
         wait_for(lambda: screen(home, after_session).count("fresh-core-text") >= 2)
         and home.manifests().get(after_session, {}).get("host_pid") == record_pid(),
-        f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={record_pid()}",
+        f"host_pid={home.manifests().get(after_session, {}).get('host_pid')} core={record_pid()} trace={core_trace()}",
     )
     # 0.5.2 regression guard for the load-storm P0: a Session that exits on a
     # core reached through the drain->fresh-core path must be REAPED — no

--- a/crates/unpeel-cli/tests/harness.py
+++ b/crates/unpeel-cli/tests/harness.py
@@ -1342,9 +1342,9 @@ class McpClient:
             self.proc.kill()
 
 
-def run_cli(home, args, timeout=30, expect_ok=None):
+def run_cli(home, args, timeout=30, expect_ok=None, env=None):
     """Run `unpeel <args>` against the fixture home."""
-    env = dict(os.environ, UNPEEL_HOME=home.root, UNPEEL_TEST="1")
+    env = dict(os.environ, UNPEEL_HOME=home.root, UNPEEL_TEST="1", **(env or {}))
     result = subprocess.run(
         [BINARY, *args],
         capture_output=True,

--- a/crates/unpeel-core/src/pty_core.rs
+++ b/crates/unpeel-core/src/pty_core.rs
@@ -154,12 +154,34 @@ impl std::fmt::Display for CoreLaunchError {
     }
 }
 
+/// `true` when the published core record carries a `host_build_id` that
+/// differs from the `unpeel-host` binary this process would launch. Records
+/// without a build id, or an unresolvable binary, are treated as matching.
+pub fn core_runs_other_build() -> bool {
+    let Some(record) = load_record() else {
+        return false;
+    };
+    let Some(current) = record.host_build_id else {
+        return false;
+    };
+    let expected = crate::session_ops::resolve_host_binary()
+        .ok()
+        .and_then(|binary| crate::session_host::host_build_id_for(&binary));
+    matches!(expected, Some(expected) if expected != current)
+}
+
 /// Ask the running core (if any) to host the Session described by
 /// `launch_file`. `Ok` carries the Session id once its preliminary manifest
 /// is on disk. The launch file is consumed by the core exactly as a
 /// per-process Host consumes it.
 pub fn try_launch_via_core(launch_file: &Path) -> Result<String, CoreLaunchError> {
     if !routing_enabled() {
+        return Err(CoreLaunchError::Unavailable);
+    }
+    if core_runs_other_build() {
+        // The running core was built from another binary (an older build
+        // left serving its Sessions after an update). Never hand it a new
+        // Session: the caller hosts it one-process until that core drains.
         return Err(CoreLaunchError::Unavailable);
     }
     let socket = socket_path();

--- a/crates/unpeel-core/src/setup.rs
+++ b/crates/unpeel-core/src/setup.rs
@@ -80,6 +80,17 @@ pub fn resolved_user_shell() -> String {
 /// average to triple digits with leftover hosts.
 const PATH_CACHE_TTL_MS: u64 = 10 * 60 * 1000;
 
+/// A probe that came back EMPTY is trusted for only this long, not the full
+/// `PATH_CACHE_TTL_MS`. An empty result is almost always transient: a shell
+/// that failed to answer under load, a half-set-up profile, or a leftover host
+/// with a stripped environment. Caching it for ten minutes lets one bad probe
+/// poison every host in the workspace — 0.5.0 deliberately never cached an
+/// empty probe at all ("must not poison the cache for the life of a
+/// long-running host"). A short TTL keeps the storm throttle (a genuinely
+/// empty PATH re-probes at most every few seconds, not every tick) without the
+/// workspace-wide poisoning window.
+const EMPTY_PATH_CACHE_TTL_MS: u64 = 5 * 1000;
+
 fn path_cache_file() -> PathBuf {
     crate::app_paths::unpeel_home().join("path-probe-cache.json")
 }
@@ -99,25 +110,34 @@ fn read_cached_shell_path_dirs() -> Option<Vec<PathBuf>> {
 }
 
 /// Pure cache-entry parse: `Some(dirs)` only when the entry carries a
-/// `probed_at_unix_ms` within the TTL of `now_ms`; stale or malformed → None.
+/// `probed_at_unix_ms` within its TTL of `now_ms`; stale or malformed → None.
+/// An empty entry uses the much shorter `EMPTY_PATH_CACHE_TTL_MS` so a
+/// transient empty probe cannot poison the workspace for the full window.
 fn parse_cached_dirs(value: &serde_json::Value, now_ms: u64) -> Option<Vec<PathBuf>> {
     let probed_at = value.get("probed_at_unix_ms").and_then(|v| v.as_u64())?;
-    if now_ms.saturating_sub(probed_at) >= PATH_CACHE_TTL_MS {
-        return None;
-    }
-    let dirs = value
+    let dirs: Vec<PathBuf> = value
         .get("dirs")?
         .as_array()?
         .iter()
         .filter_map(|v| v.as_str())
         .map(PathBuf::from)
         .collect();
+    let ttl = if dirs.is_empty() {
+        EMPTY_PATH_CACHE_TTL_MS
+    } else {
+        PATH_CACHE_TTL_MS
+    };
+    if now_ms.saturating_sub(probed_at) >= ttl {
+        return None;
+    }
     Some(dirs)
 }
 
-/// Persist the probe result for the workspace. Empty results are cached too:
-/// the point is to throttle re-probes, and a leftover/misconfigured host that
-/// probes empty must not re-storm every tick. A best-effort atomic write.
+/// Persist the probe result for the workspace. Empty results are cached too,
+/// but read back under a much shorter TTL (see `EMPTY_PATH_CACHE_TTL_MS`): the
+/// point is to throttle a re-probe storm from a leftover/misconfigured host
+/// without letting one transient empty probe poison the workspace for ten
+/// minutes. A best-effort atomic write.
 fn write_cached_shell_path_dirs(dirs: &[PathBuf]) {
     let value = serde_json::json!({
         "dirs": dirs.iter().map(|d| d.to_string_lossy()).collect::<Vec<_>>(),
@@ -330,7 +350,7 @@ pub fn dependency_report() -> DependencyReport {
 mod tests {
     use super::{
         common_bin_dirs, extract_marked, find_command_path, parse_cached_dirs,
-        platform_default_shell, runtime_command_names, PATH_CACHE_TTL_MS,
+        platform_default_shell, runtime_command_names, EMPTY_PATH_CACHE_TTL_MS, PATH_CACHE_TTL_MS,
     };
     use std::path::PathBuf;
 
@@ -354,9 +374,24 @@ mod tests {
             "probed_at_unix_ms": now - PATH_CACHE_TTL_MS,
         });
         assert_eq!(parse_cached_dirs(&stale, now), None);
-        // An empty-but-fresh entry is honored (it throttles a re-probe storm).
+        // A very-fresh empty entry is honored (it throttles a re-probe storm).
         let empty_fresh = serde_json::json!({ "dirs": [], "probed_at_unix_ms": now });
         assert_eq!(parse_cached_dirs(&empty_fresh, now), Some(Vec::new()));
+        // But an empty entry uses the SHORT TTL: past it the probe repeats,
+        // so a transient empty result cannot poison the workspace for the full
+        // ten minutes (the 0.5.1 → 0.5.2 fix for the takeover-under-load storm).
+        let empty_short_stale =
+            serde_json::json!({ "dirs": [], "probed_at_unix_ms": now - EMPTY_PATH_CACHE_TTL_MS });
+        assert_eq!(parse_cached_dirs(&empty_short_stale, now), None);
+        // A non-empty entry of the same age is still fresh (long TTL).
+        let full_same_age = serde_json::json!({
+            "dirs": ["/usr/bin"],
+            "probed_at_unix_ms": now - EMPTY_PATH_CACHE_TTL_MS,
+        });
+        assert_eq!(
+            parse_cached_dirs(&full_same_age, now),
+            Some(vec![PathBuf::from("/usr/bin")])
+        );
         // Malformed entries never parse.
         assert_eq!(
             parse_cached_dirs(&serde_json::json!({ "dirs": ["/x"] }), now),

--- a/crates/unpeel-host/tests/reap_orphan_hosts_process.rs
+++ b/crates/unpeel-host/tests/reap_orphan_hosts_process.rs
@@ -53,8 +53,35 @@ fn write_launch(home: &Path, session_id: &str, command: &str) -> PathBuf {
     path
 }
 
-fn spawn_host(home: &Path, launch: &Path) -> Child {
-    Command::new(env!("CARGO_BIN_EXE_unpeel-host"))
+/// A spawned `__session_host__` that is always torn down, even if the test
+/// panics before its explicit cleanup. Both hosts this test spawns are held
+/// in `HostProc`s so a failed assertion cannot leak a running host — the leak
+/// class Lane 23 fixed, seen again under load on 2026-09-04.
+struct HostProc {
+    child: Child,
+    pid: u32,
+}
+
+impl HostProc {
+    fn wait(&mut self) {
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for HostProc {
+    fn drop(&mut self) {
+        // The host `setsid`s at spawn, so `-pid` is its own group and never
+        // the test runner's. Both sends are harmless (ESRCH) once it is gone.
+        unsafe {
+            libc::kill(-(self.pid as i32), libc::SIGKILL);
+            libc::kill(self.pid as i32, libc::SIGKILL);
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_host(home: &Path, launch: &Path) -> HostProc {
+    let child = Command::new(env!("CARGO_BIN_EXE_unpeel-host"))
         .arg("__session_host__")
         .arg(launch)
         .env("UNPEEL_HOME", home)
@@ -65,7 +92,9 @@ fn spawn_host(home: &Path, launch: &Path) -> Child {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .unwrap()
+        .unwrap();
+    let pid = child.id();
+    HostProc { child, pid }
 }
 
 fn manifest(home: &Path, id: &str) -> Option<Value> {
@@ -95,7 +124,7 @@ fn reaps_a_filed_host_and_leaves_a_running_one() {
     let filed_launch = write_launch(&home, "filed", "sleep 600");
     let mut filed_host = spawn_host(&home, &filed_launch);
     let running_launch = write_launch(&home, "running", "sleep 600");
-    let mut running_host = spawn_host(&home, &running_launch);
+    let running_host = spawn_host(&home, &running_launch);
 
     // Both hosts record their host_pid and come up running.
     assert!(
@@ -136,7 +165,7 @@ fn reaps_a_filed_host_and_leaves_a_running_one() {
     );
     // The reaper SIGKILLed the host; reap the zombie so kill(pid, 0) stops
     // reporting the defunct entry as alive.
-    let _ = filed_host.wait();
+    filed_host.wait();
     assert!(
         wait_until(Duration::from_secs(10), || !alive(filed_pid)),
         "the filed host {filed_pid} is still alive after the reap"
@@ -153,12 +182,10 @@ fn reaps_a_filed_host_and_leaves_a_running_one() {
         Some("running".to_string())
     );
 
-    // Cleanup: stop the running host and reap the (already-dead) filed child.
-    unsafe {
-        libc::kill(-(running_pid as i32), libc::SIGKILL);
-        libc::kill(running_pid as i32, libc::SIGKILL);
-    }
-    let _ = running_host.wait();
-    let _ = filed_host.wait();
+    // Cleanup: both hosts are `HostProc`s, so they are SIGKILLed and reaped
+    // by their `Drop` at end of scope (also on any panic above). Just remove
+    // the throwaway home; the process teardown is guaranteed.
+    drop(running_host);
+    drop(filed_host);
     let _ = fs::remove_dir_all(&home);
 }

--- a/crates/unpeel-serve/src/pty_core_supervisor.rs
+++ b/crates/unpeel-serve/src/pty_core_supervisor.rs
@@ -328,6 +328,10 @@ pub struct PtyCoreSupervisor {
     allow_takeover: bool,
     /// The older-build core pid we already announced as draining.
     drain_announced: Option<u32>,
+    /// Kernel start time of the adopted core, remembered from its record:
+    /// a core removes `pty-core.json` when it exits, and the lost check must
+    /// still be able to prove that pid gone afterwards.
+    adopted_started_at: Option<u64>,
 }
 
 /// `UNPEEL_PTY_CORE_TAKEOVER=1` opts back into in-place takeovers.
@@ -358,6 +362,7 @@ impl PtyCoreSupervisor {
             takeover_attempted: None,
             allow_takeover: takeover_enabled(),
             drain_announced: None,
+            adopted_started_at: None,
         }
     }
 
@@ -643,12 +648,20 @@ impl PtyCoreSupervisor {
         match alive {
             Some(reply) => {
                 self.sessions = reply.sessions;
+                if let Some(started) = record.as_ref().and_then(|record| record.pid_started_at) {
+                    self.adopted_started_at = Some(started);
+                }
                 self.check_build_skew(events);
             }
             None => {
                 // Only a provably gone process counts as lost; an unanswered
                 // ping on a live pid is left alone (the core may be busy).
-                let started_at = record.as_ref().and_then(|record| record.pid_started_at);
+                // A core that exited removed its record, so fall back to the
+                // start time remembered while it was live.
+                let started_at = record
+                    .as_ref()
+                    .and_then(|record| record.pid_started_at)
+                    .or(self.adopted_started_at);
                 if recorded_pid_identity(pid, started_at) == PidIdentity::NotOurs {
                     self.pid = None;
                     self.sessions = None;

--- a/crates/unpeel-serve/src/pty_core_supervisor.rs
+++ b/crates/unpeel-serve/src/pty_core_supervisor.rs
@@ -318,6 +318,21 @@ pub struct PtyCoreSupervisor {
     /// One takeover attempt per (old pid, expected build): a takeover that
     /// leaves the ids mismatched must not loop.
     takeover_attempted: Option<(u32, String)>,
+    /// Whether an older-build core may be taken over in place. Off by
+    /// default since 0.5.2: the 0.5.0 -> 0.5.1 in-place takeover left the new
+    /// core unable to host new Sessions (children died at spawn and were
+    /// never reaped). Instead the older core keeps serving its Sessions, new
+    /// Sessions run one process each, and once the old core is empty it is
+    /// asked to exit so a current-build core starts. `UNPEEL_PTY_CORE_TAKEOVER=1`
+    /// re-enables the in-place path (tests, and once it is proven).
+    allow_takeover: bool,
+    /// The older-build core pid we already announced as draining.
+    drain_announced: Option<u32>,
+}
+
+/// `UNPEEL_PTY_CORE_TAKEOVER=1` opts back into in-place takeovers.
+pub fn takeover_enabled() -> bool {
+    std::env::var("UNPEEL_PTY_CORE_TAKEOVER").is_ok_and(|value| value.trim() == "1")
 }
 
 impl PtyCoreSupervisor {
@@ -341,10 +356,17 @@ impl PtyCoreSupervisor {
             takeover_from: None,
             takeover_started_at: Instant::now(),
             takeover_attempted: None,
+            allow_takeover: takeover_enabled(),
+            drain_announced: None,
         }
     }
 
     /// Pin the build id takeovers are measured against (tests).
+    /// Tests pin the in-place takeover policy explicitly.
+    pub fn set_allow_takeover(&mut self, allow: bool) {
+        self.allow_takeover = allow;
+    }
+
     pub fn set_expected_build_id(&mut self, build_id: Option<String>) {
         self.expected_build_id = build_id;
         self.probe_expected_build_id = false;
@@ -422,6 +444,10 @@ impl PtyCoreSupervisor {
         if current == expected {
             return;
         }
+        if !self.allow_takeover {
+            self.drain_older_core(old_pid, &record.socket, events);
+            return;
+        }
         if self.takeover_attempted.as_ref() == Some(&(old_pid, expected.clone())) {
             return;
         }
@@ -439,6 +465,33 @@ impl PtyCoreSupervisor {
             Err(error) => events.push(CoreEvent::Warning(format!(
                 "could not start a takeover core: {error}"
             ))),
+        }
+    }
+
+    /// An adopted core runs an older build and in-place takeover is off:
+    /// leave it serving its Sessions (spawn routing already refuses it, so
+    /// new Sessions run one process each) and, once it holds none, ask it to
+    /// exit so the normal lost-core path starts a current-build core. Never
+    /// signals anything.
+    fn drain_older_core(&mut self, old_pid: u32, socket: &Path, events: &mut Vec<CoreEvent>) {
+        let sessions = self.sessions.unwrap_or(u64::MAX);
+        if sessions == 0 {
+            match unpeel_core::pty_core::shutdown_at(socket, HEALTH_INTERVAL) {
+                Ok(()) => events.push(CoreEvent::Warning(format!(
+                    "PTY core pid {old_pid} runs an older build and holds no Sessions; asked it to exit so a current-build core can start"
+                ))),
+                Err(error) => events.push(CoreEvent::Warning(format!(
+                    "PTY core pid {old_pid} runs an older build and holds no Sessions, but did not accept shutdown: {error}"
+                ))),
+            }
+            self.drain_announced = None;
+            return;
+        }
+        if self.drain_announced != Some(old_pid) {
+            self.drain_announced = Some(old_pid);
+            events.push(CoreEvent::Warning(format!(
+                "PTY core pid {old_pid} runs an older build; it keeps serving its {sessions} Session(s) and new terminals run one process each until it drains (in-place takeover is off)"
+            )));
         }
     }
 
@@ -785,6 +838,50 @@ mod tests {
         }
     }
 
+    #[test]
+    fn older_build_core_drains_instead_of_takeover() {
+        let home = short_home();
+        let mut parked = std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let core = FakeCore::start(home.path(), parked.id(), 2);
+        core.write_record(home.path(), None);
+        let (mut supervisor, events) =
+            PtyCoreSupervisor::start(home.path().to_path_buf(), never_spawn());
+        assert!(matches!(events.as_slice(), [CoreEvent::Adopted { .. }]));
+        supervisor.set_allow_takeover(false);
+        supervisor.set_expected_build_id(Some("newer".into()));
+
+        // Holding Sessions: announced once, never taken over, never spawned.
+        let mut events = Vec::new();
+        supervisor.check_build_skew(&mut events);
+        assert!(
+            matches!(events.as_slice(), [CoreEvent::Warning(message)] if message.contains("keeps serving its 2 Session")),
+            "{events:?}"
+        );
+        assert_eq!(supervisor.state(), CoreState::Adopted);
+        let mut again = Vec::new();
+        supervisor.check_build_skew(&mut again);
+        assert!(again.is_empty(), "announced once: {again:?}");
+
+        // Empty: asked to exit (the fake refuses; the supervisor only reports).
+        supervisor.sessions = Some(0);
+        let mut events = Vec::new();
+        supervisor.check_build_skew(&mut events);
+        assert!(
+            matches!(events.as_slice(), [CoreEvent::Warning(message)] if message.contains("holds no Sessions")),
+            "{events:?}"
+        );
+        assert_eq!(supervisor.state(), CoreState::Adopted);
+        drop(core);
+        let _ = parked.kill();
+        let _ = parked.wait();
+    }
+
     fn short_home() -> tempfile::TempDir {
         // Unix socket paths must stay short.
         tempfile::Builder::new()
@@ -1037,6 +1134,7 @@ mod tests {
         assert!(matches!(events.as_slice(), [CoreEvent::Adopted { .. }]));
         assert_eq!(supervisor.state(), CoreState::Adopted);
 
+        supervisor.set_allow_takeover(true);
         // Same build: no takeover.
         supervisor.set_expected_build_id(Some("test".into()));
         let mut events = Vec::new();


### PR DESCRIPTION
Plan B for the 0.5.1 takeover regression (build 44 pulled from beta).

- Supervisor: an adopted core built from another binary is no longer taken over in place. It keeps serving its Sessions; once it holds none it is asked to exit and the normal lost-core path starts a current-build core. `UNPEEL_PTY_CORE_TAKEOVER=1` re-enables the in-place path.
- Spawn routing: `try_launch_via_core` refuses a core whose `host_build_id` differs from the `unpeel-host` this process would launch, so new Sessions run one process each until the old core drains.
- Tests: supervisor unit test for the drain policy; the `pty_core_handoff` matrix case keeps the in-place takeover section (with the opt-in env) and now proves the drain policy end to end (older core keeps its session, a new Session spawns one-process and survives, the emptied core exits 0, the next Session lands in the fresh core).

Gates so far: fmt, clippy -D warnings (workspace), supervisor + core unit tests. Matrix case running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)