### PR TITLE
serve: bound unauthenticated connections; pid identity before treating a process as session-owned

### DIFF
--- a/crates/unpeel-core/src/local_urls.rs
+++ b/crates/unpeel-core/src/local_urls.rs
@@ -172,6 +172,10 @@ pub fn dedupe_by_origin(urls: &[String]) -> Vec<String> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocalSiteServer {
     pub pid: u32,
+    /// Kernel start time of `pid` when it was resolved. A Stop revalidates
+    /// against it immediately before signaling, so a pid recycled between
+    /// resolve and signal is never the target.
+    pub pid_started_at: Option<u64>,
     /// Short command name, for display ("node", "python3").
     pub command: String,
     /// The hosted session whose process tree contains the server — the only
@@ -185,18 +189,23 @@ pub struct LocalSiteServer {
 pub fn server_for_url(url: &str) -> Option<LocalSiteServer> {
     let (port, _) = extract_local_urls(url).into_iter().next()?;
     let pid = listening_pid(port)?;
+    let pid_started_at = crate::session_host::process_start_time_ms(pid);
     let command = process_command(pid).unwrap_or_default();
     Some(LocalSiteServer {
         pid,
+        pid_started_at,
         command,
-        session_id: owning_session(pid),
+        session_id: owning_session_in(&crate::app_paths::app_sessions_root(), pid),
     })
 }
 
 /// Stop the server behind `url`, but only when it still resolves to a
 /// session-owned process at this very moment — resolve-and-kill in one
 /// step, so a stale pid can never be signaled (kill paths here follow the
-/// same identity discipline as the session-host kill paths).
+/// same identity discipline as the session-host kill paths). The target's
+/// identity is pid + kernel start time, re-verified right before the signal:
+/// a pid recycled after resolve, or one whose start time the kernel would
+/// not report, is never signaled.
 pub fn stop_server_for_url(url: &str) -> Result<LocalSiteServer, String> {
     let server = server_for_url(url).ok_or("no server is listening on that port")?;
     if server.session_id.is_none() {
@@ -205,11 +214,30 @@ pub fn stop_server_for_url(url: &str) -> Result<LocalSiteServer, String> {
             server.command, server.pid
         ));
     }
+    verify_stop_target(&server)?;
     let rc = unsafe { libc::kill(server.pid as i32, libc::SIGTERM) };
     if rc == 0 {
         Ok(server)
     } else {
         Err(format!("failed to signal pid {}", server.pid))
+    }
+}
+
+/// The last check before a signal: the live process under `server.pid` must
+/// still be the one resolved (same kernel start time). A recycled pid, a
+/// resolve that could not read a start time, or a kernel query failure now
+/// all refuse — never a bare-pid signal.
+fn verify_stop_target(server: &LocalSiteServer) -> Result<(), String> {
+    let verified = server.pid_started_at.is_some()
+        && crate::session_host::recorded_pid_identity(server.pid, server.pid_started_at)
+            == crate::session_host::PidIdentity::Matches;
+    if verified {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} (pid {}) could not be verified as the same process; not signaled",
+            server.command, server.pid
+        ))
     }
 }
 
@@ -247,13 +275,17 @@ fn parent_pid(pid: u32) -> Option<u32> {
     String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
-/// Walk the server's ancestry against the running session manifests: any
-/// ancestor matching a manifest's recorded host pid ties the server to
-/// that session.
-fn owning_session(pid: u32) -> Option<String> {
+/// Walk the server's ancestry against the running session manifests under
+/// `sessions_root`: any ancestor matching a manifest's recorded child pid
+/// ties the server to that session. A manifest counts only when its pid is
+/// positively identified as the session's own child (`PidIdentity::Matches`,
+/// pid + recorded kernel start time): a Running record whose child died and
+/// whose pid the OS recycled onto an unrelated process must not claim that
+/// process's descendants as session-owned, because the answer here is what
+/// authorizes a Stop signal. `Unknown` is treated as not ours too.
+fn owning_session_in(sessions_root: &std::path::Path, pid: u32) -> Option<String> {
     let mut session_by_pid = std::collections::HashMap::new();
-    let root = crate::app_paths::app_sessions_root();
-    for entry in std::fs::read_dir(root).ok()?.flatten() {
+    for entry in std::fs::read_dir(sessions_root).ok()?.flatten() {
         let bytes = match std::fs::read(entry.path().join("manifest.json")) {
             Ok(bytes) => bytes,
             Err(_) => continue,
@@ -263,11 +295,18 @@ fn owning_session(pid: u32) -> Option<String> {
         else {
             continue;
         };
-        if manifest.state == crate::session_host::HostedSessionState::Running {
-            if let Some(host_pid) = manifest.pid {
-                session_by_pid.insert(host_pid, manifest.session.id.clone());
-            }
+        if manifest.state != crate::session_host::HostedSessionState::Running {
+            continue;
         }
+        let Some(child_pid) = manifest.pid else {
+            continue;
+        };
+        if crate::session_host::manifest_pid_identity(&manifest)
+            != crate::session_host::PidIdentity::Matches
+        {
+            continue;
+        }
+        session_by_pid.insert(child_pid, manifest.session.id.clone());
     }
     let mut current = pid;
     for _ in 0..12 {
@@ -479,6 +518,130 @@ fn path_length(after_port: &str) -> usize {
 mod tests {
     use super::*;
     use std::net::TcpListener;
+
+    /// A live process that is NOT a session child, standing in for whatever
+    /// the OS recycled a dead session's pid onto.
+    fn unrelated_live_process() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep")
+    }
+
+    fn write_running_manifest(
+        root: &std::path::Path,
+        session_id: &str,
+        pid: u32,
+        pid_started_at: Option<u64>,
+    ) {
+        let dir = root.join(session_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut manifest = serde_json::json!({
+            "session": {
+                "id": session_id,
+                "project_id": "p1",
+                "label": "stale",
+                "command": "bash",
+            },
+            "cwd": "/tmp",
+            "state": "running",
+            "pid": pid,
+            "exit_code": null,
+        });
+        if let Some(started) = pid_started_at {
+            manifest["pid_started_at"] = serde_json::json!(started);
+        }
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn scratch_sessions_root(label: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "unpeel-local-urls-{label}-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn recycled_pid_in_running_manifest_does_not_own_a_web_server() {
+        let mut stranger = unrelated_live_process();
+        let pid = stranger.id();
+        let actual_start = crate::session_host::process_start_time_ms(pid)
+            .expect("kernel reports the start time of a live child");
+        let root = scratch_sessions_root("recycled");
+        // The session's child died and the OS handed its pid to `stranger`:
+        // the manifest still says Running, but its recorded start time is an
+        // hour off the live process's.
+        write_running_manifest(&root, "stale-record", pid, Some(actual_start - 3_600_000));
+        assert_eq!(
+            crate::session_host::recorded_pid_identity(pid, Some(actual_start - 3_600_000)),
+            crate::session_host::PidIdentity::NotOurs
+        );
+
+        assert_eq!(owning_session_in(&root, pid), None);
+
+        // Control: the same manifest with the true start time is the child.
+        write_running_manifest(&root, "stale-record", pid, Some(actual_start));
+        assert_eq!(
+            owning_session_in(&root, pid),
+            Some("stale-record".to_string())
+        );
+
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_manifest_without_start_time_does_not_own_a_web_server() {
+        let mut stranger = unrelated_live_process();
+        let pid = stranger.id();
+        let root = scratch_sessions_root("legacy");
+        // No `pid_started_at` and an argv that never mentions the session:
+        // identity is Unknown, which is not ownership.
+        write_running_manifest(&root, "legacy-record", pid, None);
+
+        assert_eq!(owning_session_in(&root, pid), None);
+
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn stop_target_is_refused_when_the_pid_was_recycled_after_resolve() {
+        let mut stranger = unrelated_live_process();
+        let pid = stranger.id();
+        let actual_start = crate::session_host::process_start_time_ms(pid).unwrap();
+        let resolved = |pid_started_at: Option<u64>| LocalSiteServer {
+            pid,
+            pid_started_at,
+            command: "sleep".into(),
+            session_id: Some("owner".into()),
+        };
+
+        // Resolved against a process that has since been replaced.
+        assert!(verify_stop_target(&resolved(Some(actual_start - 3_600_000))).is_err());
+        // Resolved without a start time: nothing to verify against.
+        assert!(verify_stop_target(&resolved(None)).is_err());
+        // The same process: allowed.
+        assert!(verify_stop_target(&resolved(Some(actual_start))).is_ok());
+        // Neither refusal signaled the stranger.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(stranger.try_wait().unwrap().is_none(), "stranger survived");
+
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+    }
 
     #[test]
     fn extracts_plain_localhost_url() {

--- a/crates/unpeel-core/src/session_host.rs
+++ b/crates/unpeel-core/src/session_host.rs
@@ -3614,8 +3614,12 @@ pub enum PidIdentity {
     Unknown,
 }
 
+/// Kernel-reported start time of `pid` in ms since the epoch — the half of a
+/// process identity that a bare pid lacks. Record it next to every pid you
+/// persist (`pid_started_at`) so `recorded_pid_identity` can verify the
+/// process later. `None` when the process is gone or the kernel query failed.
 #[cfg(target_os = "macos")]
-pub(crate) fn process_start_time_ms(pid: u32) -> Option<u64> {
+pub fn process_start_time_ms(pid: u32) -> Option<u64> {
     let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::uninit();
     let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
     let rc = unsafe {
@@ -3635,7 +3639,7 @@ pub(crate) fn process_start_time_ms(pid: u32) -> Option<u64> {
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) fn process_start_time_ms(pid: u32) -> Option<u64> {
+pub fn process_start_time_ms(pid: u32) -> Option<u64> {
     // /proc/<pid>/stat: field 22 is starttime in clock ticks since boot; the
     // comm field can contain spaces, so parse from after the closing paren.
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
@@ -3656,7 +3660,7 @@ pub(crate) fn process_start_time_ms(pid: u32) -> Option<u64> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub(crate) fn process_start_time_ms(_pid: u32) -> Option<u64> {
+pub fn process_start_time_ms(_pid: u32) -> Option<u64> {
     None
 }
 

--- a/crates/unpeel-core/src/session_io.rs
+++ b/crates/unpeel-core/src/session_io.rs
@@ -1845,8 +1845,14 @@ impl HandedOverChild {
 }
 
 impl portable_pty::ChildKiller for HandedOverChild {
+    /// Signals only a positively identified child (pid + recorded kernel
+    /// start time). A handoff without a start time still reports liveness
+    /// through the bare probe above, but it must never be a kill target: the
+    /// pid may have been recycled onto a stranger since the old core spawned
+    /// it. Worst case an orphaned shell lingers, which beats killing an
+    /// unrelated process.
     fn kill(&mut self) -> std::io::Result<()> {
-        if !self.alive() {
+        if recorded_pid_identity(self.pid, self.started_at) != PidIdentity::Matches {
             return Ok(());
         }
         if unsafe { libc::kill(self.pid as i32, libc::SIGKILL) } != 0 {
@@ -2099,4 +2105,48 @@ pub(crate) fn record_child_exit(
         _ => portable_pty::ExitStatus::with_exit_code(0),
     };
     *slot.lock().unwrap() = Some(status);
+}
+
+#[cfg(test)]
+mod handed_over_child_tests {
+    use super::*;
+    use portable_pty::ChildKiller;
+
+    /// A live process that is NOT the handed-over child, standing in for
+    /// whatever the OS recycled the recorded pid onto.
+    fn unrelated_live_process() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep")
+    }
+
+    #[test]
+    fn kill_never_signals_a_recycled_or_unproven_pid() {
+        let mut stranger = unrelated_live_process();
+        let pid = stranger.id();
+        let actual_start = process_start_time_ms(pid).expect("start time of a live child");
+
+        // Recorded an hour before the live process started: recycled pid.
+        let mut recycled = HandedOverChild::new(pid, Some(actual_start - 3_600_000));
+        assert!(recycled.kill().is_ok());
+        // Legacy handoff without a start time: liveness is reported, but
+        // identity is unproven, so no signal.
+        let mut unproven = HandedOverChild::new(pid, None);
+        assert!(unproven.kill().is_ok());
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            stranger.try_wait().unwrap().is_none(),
+            "an unrelated process under the recorded pid must survive kill()"
+        );
+
+        // The genuine child (matching start time) is signaled.
+        let mut ours = HandedOverChild::new(pid, Some(actual_start));
+        assert!(ours.kill().is_ok());
+        let status = stranger.wait().unwrap();
+        assert!(!status.success(), "SIGKILL reached the verified child");
+    }
 }

--- a/crates/unpeel-serve/src/mobile.rs
+++ b/crates/unpeel-serve/src/mobile.rs
@@ -33,6 +33,20 @@ use crate::platform_adapter::{PlatformAdapterError, PlatformAdapterHub};
 
 const IO_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_BODY: usize = 4 * 1024 * 1024;
+/// Wall-clock budget for a connection to authenticate, measured from accept.
+/// The per-read `IO_TIMEOUT` alone lets a slow sender hold a worker thread
+/// indefinitely by pacing one byte per read; the accept loop shuts down any
+/// connection still unauthenticated past this deadline, which interrupts
+/// the worker's blocking read regardless of how the bytes were paced.
+const PRE_AUTH_DEADLINE: Duration = Duration::from_secs(5);
+/// Ceiling on concurrently served connections. The excess is answered 503
+/// and closed on the accept thread, so it never earns a worker thread.
+const MAX_CONNECTIONS: usize = 64;
+/// Per-peer-address share of `MAX_CONNECTIONS`, so one client (a phone opens
+/// a handful of URLSession connections, never more) cannot fill the pool.
+const MAX_CONNECTIONS_PER_PEER: usize = 16;
+/// How often the accept loop looks for expired unauthenticated connections.
+const LEDGER_SWEEP_INTERVAL: Duration = Duration::from_millis(100);
 /// The TUI main loop publishes the phone-facing snapshot here every rescan:
 /// pre-built bootstrap arrays plus the project-scoped archive catalog, all in
 /// the Swift wire dialect and desktop sidebar order.
@@ -908,6 +922,7 @@ fn respond(stream: &mut TcpStream, status: u16, body: &str, keep_alive: bool) ->
         405 => "Method Not Allowed",
         500 => "Internal Server Error",
         501 => "Not Implemented",
+        503 => "Service Unavailable",
         504 => "Gateway Timeout",
         _ => "Error",
     };
@@ -936,15 +951,31 @@ fn session_dir(id: &str) -> std::path::PathBuf {
 /// Live `__remote__` advertisement (port + TLS fingerprint) when that server
 /// runs — the app or a future TUI supervisor spawns it; we just relay state.
 pub(crate) fn remote_server_advertisement() -> (Option<u64>, Option<String>) {
-    let Ok(raw) = std::fs::read(app_paths::unpeel_home().join("remote.json")) else {
+    remote_server_advertisement_at(&app_paths::unpeel_home())
+}
+
+/// The record names its own pid and kernel start time (`pid_started_at`,
+/// written by `__remote__` at startup). Only a pid that provably started
+/// when the record says is the streamer: a bare liveness probe would relay
+/// a dead streamer's port and fingerprint whenever the pid was recycled onto
+/// an unrelated process, and a record without a start time proves nothing.
+fn remote_server_advertisement_at(home: &std::path::Path) -> (Option<u64>, Option<String>) {
+    let Ok(raw) = std::fs::read(home.join("remote.json")) else {
         return (None, None);
     };
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(&raw) else {
         return (None, None);
     };
-    let pid = value.get("pid").and_then(|v| v.as_u64());
-    let alive = pid.is_some_and(|p| unsafe { libc::kill(p as libc::pid_t, 0) == 0 });
-    if !alive {
+    let pid = value
+        .get("pid")
+        .and_then(|v| v.as_u64())
+        .and_then(|pid| u32::try_from(pid).ok());
+    let started_at = value.get("pid_started_at").and_then(|v| v.as_u64());
+    let is_streamer = pid.is_some_and(|pid| {
+        unpeel_core::session_host::recorded_pid_identity(pid, started_at)
+            == unpeel_core::session_host::PidIdentity::Matches
+    });
+    if !is_streamer {
         return (None, None);
     }
     (
@@ -1962,6 +1993,147 @@ fn handle_pairing_invitation(
     }
 }
 
+/// One admitted connection as the accept loop tracks it: who it came from,
+/// when, and whether its worker has seen a valid bearer token yet.
+struct ConnectionSlot {
+    peer: std::net::IpAddr,
+    accepted_at: Instant,
+    authenticated: Arc<std::sync::atomic::AtomicBool>,
+    /// Set once the sweep has cut this connection, so a slow worker that
+    /// has not yet released the slot is not shut down on every tick.
+    expired: bool,
+}
+
+/// Connection accounting for the accept loop: a global cap, a per-peer cap,
+/// and a pre-authentication deadline. Pure bookkeeping — it never touches a
+/// socket itself — so the policy is testable without a listener.
+pub(crate) struct ConnectionLedger {
+    max_total: usize,
+    max_per_peer: usize,
+    pre_auth_deadline: Duration,
+    slots: HashMap<u64, ConnectionSlot>,
+    per_peer: HashMap<std::net::IpAddr, usize>,
+    last_sweep: Instant,
+}
+
+impl ConnectionLedger {
+    pub(crate) fn new(max_total: usize, max_per_peer: usize, pre_auth_deadline: Duration) -> Self {
+        Self {
+            max_total,
+            max_per_peer,
+            pre_auth_deadline,
+            slots: HashMap::new(),
+            per_peer: HashMap::new(),
+            last_sweep: Instant::now(),
+        }
+    }
+
+    fn with_defaults() -> Self {
+        Self::new(MAX_CONNECTIONS, MAX_CONNECTIONS_PER_PEER, PRE_AUTH_DEADLINE)
+    }
+
+    /// Admit `id` from `peer` at `now`, returning the flag the worker flips
+    /// once the connection authenticates; `None` means the caps refuse it.
+    pub(crate) fn admit(
+        &mut self,
+        id: u64,
+        peer: std::net::IpAddr,
+        now: Instant,
+    ) -> Option<Arc<std::sync::atomic::AtomicBool>> {
+        let peer_count = self.per_peer.get(&peer).copied().unwrap_or(0);
+        if self.slots.len() >= self.max_total || peer_count >= self.max_per_peer {
+            return None;
+        }
+        let authenticated = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.slots.insert(
+            id,
+            ConnectionSlot {
+                peer,
+                accepted_at: now,
+                authenticated: Arc::clone(&authenticated),
+                expired: false,
+            },
+        );
+        self.per_peer.insert(peer, peer_count + 1);
+        Some(authenticated)
+    }
+
+    /// The worker for `id` exited; free its global and per-peer share.
+    pub(crate) fn release(&mut self, id: u64) {
+        let Some(slot) = self.slots.remove(&id) else {
+            return;
+        };
+        if let Some(count) = self.per_peer.get_mut(&slot.peer) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.per_peer.remove(&slot.peer);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Connections still unauthenticated past the deadline as of `now`, each
+    /// reported once. Rate-limited to `LEDGER_SWEEP_INTERVAL` so a flood of
+    /// accepts does not turn every iteration into a full scan.
+    pub(crate) fn expired(&mut self, now: Instant) -> Vec<u64> {
+        if now.saturating_duration_since(self.last_sweep) < LEDGER_SWEEP_INTERVAL {
+            return Vec::new();
+        }
+        self.last_sweep = now;
+        let deadline = self.pre_auth_deadline;
+        self.slots
+            .iter_mut()
+            .filter(|(_, slot)| {
+                !slot.expired
+                    && !slot
+                        .authenticated
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                    && now.saturating_duration_since(slot.accepted_at) >= deadline
+            })
+            .map(|(id, slot)| {
+                slot.expired = true;
+                *id
+            })
+            .collect()
+    }
+}
+
+/// Refuse a connection the ledger would not admit: a one-line 503 written
+/// on the accept thread (a fresh socket's send buffer is empty, so this does
+/// not block), then the stream drops and closes. Never spawns a worker.
+fn refuse_overloaded(mut stream: TcpStream) {
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(1)));
+    respond(&mut stream, 503, &error_body("too many connections"), false);
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+}
+
+/// Cut every connection the ledger reports as expired: `shutdown(Both)` on
+/// the control clone interrupts the worker's blocking read, so the worker
+/// exits and releases its slot through the normal path.
+fn cut_expired_connections(
+    ledger: &Mutex<ConnectionLedger>,
+    connections: &Mutex<HashMap<u64, TcpStream>>,
+) {
+    let expired = ledger
+        .lock()
+        .map(|mut ledger| ledger.expired(Instant::now()))
+        .unwrap_or_default();
+    if expired.is_empty() {
+        return;
+    }
+    if let Ok(connections) = connections.lock() {
+        for id in expired {
+            if let Some(stream) = connections.get(&id) {
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_connection(
     mut stream: TcpStream,
@@ -1975,6 +2147,7 @@ fn handle_connection(
     presence: Option<Arc<crate::presence::PresenceHub>>,
     direct_endpoint: Arc<str>,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
+    authenticated: Arc<std::sync::atomic::AtomicBool>,
 ) {
     let _ = stream.set_read_timeout(Some(IO_TIMEOUT));
     let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
@@ -2014,6 +2187,7 @@ fn handle_connection(
                     respond(&mut stream, 401, &error_body("unauthorized"), keep);
                 }
                 Some(principal) => {
+                    authenticated.store(true, std::sync::atomic::Ordering::Relaxed);
                     let (status, body) = handle_authenticated(
                         &request,
                         &principal,
@@ -2281,13 +2455,32 @@ fn start_impl(
     let accept_shutdown = Arc::clone(&shutdown);
     let accept_connections = Arc::clone(&active_connections);
     let accept_workers = Arc::clone(&worker_threads);
+    // Connection accounting: the global and per-peer caps refuse the excess
+    // with a 503 before it earns a thread, and the sweep cuts connections
+    // that are still unauthenticated past `PRE_AUTH_DEADLINE` however slowly
+    // they paced their bytes.
+    let ledger = Arc::new(Mutex::new(ConnectionLedger::with_defaults()));
     let accept_thread = std::thread::spawn(move || loop {
         if accept_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
             return; // listener drops here, releasing the port
         }
+        cut_expired_connections(&ledger, &accept_connections);
         match listener.accept() {
-            Ok((stream, _)) => {
+            Ok((stream, peer)) => {
                 let _ = stream.set_nonblocking(false);
+                let connection_id = {
+                    static NEXT_CONNECTION_ID: std::sync::atomic::AtomicU64 =
+                        std::sync::atomic::AtomicU64::new(1);
+                    NEXT_CONNECTION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                };
+                let admitted = ledger
+                    .lock()
+                    .ok()
+                    .and_then(|mut ledger| ledger.admit(connection_id, peer.ip(), Instant::now()));
+                let Some(authenticated) = admitted else {
+                    refuse_overloaded(stream);
+                    continue;
+                };
                 let snapshot = Arc::clone(&snapshot);
                 let mark_read = mark_read.clone();
                 let resizes = Arc::clone(&resizes);
@@ -2298,11 +2491,7 @@ fn start_impl(
                 let direct_endpoint = Arc::clone(&direct_endpoint);
                 let connection_shutdown = Arc::clone(&accept_shutdown);
                 let connections = Arc::clone(&accept_connections);
-                let connection_id = {
-                    static NEXT_CONNECTION_ID: std::sync::atomic::AtomicU64 =
-                        std::sync::atomic::AtomicU64::new(1);
-                    NEXT_CONNECTION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                };
+                let worker_ledger = Arc::clone(&ledger);
                 if let Ok(control) = stream.try_clone() {
                     if let Ok(mut guard) = connections.lock() {
                         guard.insert(connection_id, control);
@@ -2321,9 +2510,13 @@ fn start_impl(
                         presence,
                         direct_endpoint,
                         connection_shutdown,
+                        authenticated,
                     );
                     if let Ok(mut guard) = connections.lock() {
                         guard.remove(&connection_id);
+                    }
+                    if let Ok(mut ledger) = worker_ledger.lock() {
+                        ledger.release(connection_id);
                     }
                 });
                 if let Ok(mut workers) = accept_workers.lock() {
@@ -2374,6 +2567,261 @@ mod tests {
 
     fn scratch_dir(label: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("unpeel-mobile-{label}-{}", uuid::Uuid::new_v4()))
+    }
+
+    /// A live process that is NOT the `__remote__` streamer, standing in for
+    /// whatever the OS recycled a dead streamer's pid onto.
+    fn unrelated_live_process() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep")
+    }
+
+    #[test]
+    fn remote_advertisement_requires_the_recorded_streamer_identity() {
+        let mut stranger = unrelated_live_process();
+        let pid = stranger.id();
+        let actual_start = unpeel_core::session_host::process_start_time_ms(pid)
+            .expect("start time of a live child");
+        let home = scratch_dir("remote-advertisement");
+        std::fs::create_dir_all(&home).unwrap();
+        let write = |pid_started_at: Option<u64>| {
+            let mut record = serde_json::json!({
+                "pid": pid,
+                "port": 45_123,
+                "fingerprint": "ab:cd",
+            });
+            if let Some(started) = pid_started_at {
+                record["pid_started_at"] = serde_json::json!(started);
+            }
+            std::fs::write(home.join("remote.json"), record.to_string()).unwrap();
+        };
+
+        // The recorded streamer died and its pid was recycled: nothing to
+        // advertise, even though `kill(pid, 0)` would succeed.
+        write(Some(actual_start - 3_600_000));
+        assert_eq!(remote_server_advertisement_at(&home), (None, None));
+        // A record without a start time proves nothing either.
+        write(None);
+        assert_eq!(remote_server_advertisement_at(&home), (None, None));
+        // The live process is the recorded streamer: relay its endpoint.
+        write(Some(actual_start));
+        assert_eq!(
+            remote_server_advertisement_at(&home),
+            (Some(45_123), Some("ab:cd".to_string()))
+        );
+
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn connection_ledger_enforces_caps_and_pre_auth_deadline() {
+        let deadline = Duration::from_millis(500);
+        let mut ledger = ConnectionLedger::new(3, 2, deadline);
+        let t0 = Instant::now();
+        let a: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        let b: std::net::IpAddr = "10.0.0.2".parse().unwrap();
+
+        let a1 = ledger.admit(1, a, t0).expect("first from a");
+        assert!(ledger.admit(2, a, t0).is_some(), "second from a");
+        assert!(
+            ledger.admit(3, a, t0).is_none(),
+            "per-peer cap refuses a third"
+        );
+        assert!(ledger.admit(4, b, t0).is_some(), "b still has room");
+        assert!(
+            ledger.admit(5, b, t0).is_none(),
+            "global cap refuses the fourth"
+        );
+        assert_eq!(ledger.len(), 3);
+
+        // Nothing has expired before the deadline; the first sweep runs.
+        assert!(ledger.expired(t0 + Duration::from_millis(200)).is_empty());
+        // An authenticated connection outlives the pre-auth deadline.
+        a1.store(true, std::sync::atomic::Ordering::Relaxed);
+        let mut expired = ledger.expired(t0 + deadline + LEDGER_SWEEP_INTERVAL);
+        expired.sort_unstable();
+        assert_eq!(expired, vec![2, 4]);
+        // Each expiry is reported once.
+        assert!(ledger
+            .expired(t0 + deadline + 2 * LEDGER_SWEEP_INTERVAL)
+            .is_empty());
+
+        // Releasing frees the per-peer and global share.
+        ledger.release(2);
+        ledger.release(4);
+        assert_eq!(ledger.len(), 1);
+        assert!(ledger.admit(6, a, t0).is_some());
+        assert!(ledger.admit(7, b, t0).is_some());
+        assert!(
+            ledger.admit(8, b, t0).is_none(),
+            "global cap holds after reuse"
+        );
+    }
+
+    /// End to end on a real listener: N slow unauthenticated clients are
+    /// admitted, the (N+1)th is refused with a 503 immediately, and the slow
+    /// ones are cut at the pre-auth deadline — after which a new client is
+    /// admitted again. Mirrors the production accept loop in `start_impl`
+    /// (ledger admit → worker → release, expiry sweep on every iteration).
+    #[test]
+    fn slow_unauthenticated_connections_are_capped_and_cut_at_the_deadline() {
+        const CAP: usize = 4;
+        let deadline = Duration::from_millis(500);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        listener.set_nonblocking(true).unwrap();
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ledger = Arc::new(Mutex::new(ConnectionLedger::new(CAP, CAP, deadline)));
+        let connections = Arc::new(Mutex::new(HashMap::<u64, TcpStream>::new()));
+
+        let accept_shutdown = Arc::clone(&shutdown);
+        let accept_ledger = Arc::clone(&ledger);
+        let accept_connections = Arc::clone(&connections);
+        let accept_thread = std::thread::spawn(move || {
+            let mut workers = Vec::new();
+            let mut next_id = 1u64;
+            loop {
+                if accept_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                    break;
+                }
+                cut_expired_connections(&accept_ledger, &accept_connections);
+                match listener.accept() {
+                    Ok((stream, peer)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let id = next_id;
+                        next_id += 1;
+                        let admitted =
+                            accept_ledger
+                                .lock()
+                                .unwrap()
+                                .admit(id, peer.ip(), Instant::now());
+                        let Some(authenticated) = admitted else {
+                            refuse_overloaded(stream);
+                            continue;
+                        };
+                        accept_connections
+                            .lock()
+                            .unwrap()
+                            .insert(id, stream.try_clone().unwrap());
+                        let worker_ledger = Arc::clone(&accept_ledger);
+                        let worker_connections = Arc::clone(&accept_connections);
+                        let worker_shutdown = Arc::clone(&accept_shutdown);
+                        workers.push(std::thread::spawn(move || {
+                            let (mark_read, _receiver) = std::sync::mpsc::channel();
+                            handle_connection(
+                                stream,
+                                Arc::new(Mutex::new(crate::sessions::MobileSnapshot::default())),
+                                mark_read,
+                                None,
+                                Arc::new(Mutex::new(HashMap::new())),
+                                Arc::new(crate::approvals::ApprovalHub::default()),
+                                Arc::new(crate::pairing::PairingWindow::default()),
+                                Arc::new(PlatformAdapterHub::default()),
+                                None,
+                                "http://127.0.0.1:17661/mobile".into(),
+                                worker_shutdown,
+                                authenticated,
+                            );
+                            worker_connections.lock().unwrap().remove(&id);
+                            worker_ledger.lock().unwrap().release(id);
+                        }));
+                    }
+                    Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(_) => break,
+                }
+            }
+            for stream in accept_connections.lock().unwrap().values() {
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            }
+            for worker in workers {
+                let _ = worker.join();
+            }
+        });
+
+        let connect = || {
+            let client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+            client
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            client
+        };
+        // N slow senders: a partial request head, then silence.
+        let opened_at = Instant::now();
+        let mut slow: Vec<TcpStream> = (0..CAP)
+            .map(|_| {
+                let mut client = connect();
+                client.write_all(b"GET /mob").unwrap();
+                client
+            })
+            .collect();
+        let admitted_deadline = Instant::now() + Duration::from_secs(5);
+        while ledger.lock().unwrap().len() < CAP {
+            assert!(
+                Instant::now() < admitted_deadline,
+                "slow clients were admitted"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        // The (N+1)th is refused promptly, before any slow client expires.
+        let refused_at = Instant::now();
+        let mut refused = connect();
+        let mut response = Vec::new();
+        refused.read_to_end(&mut response).unwrap();
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 503 "), "{response}");
+        assert!(response.contains("Connection: close"), "{response}");
+        assert!(
+            refused_at.elapsed() < Duration::from_secs(2),
+            "refusal was immediate, not queued behind the slow clients"
+        );
+
+        // The slow ones are cut at the deadline: each read ends (EOF or
+        // reset) well before the 30 s per-read timeout would.
+        for client in &mut slow {
+            let mut buffer = [0u8; 64];
+            match client.read(&mut buffer) {
+                Ok(0) | Err(_) => {}
+                Ok(n) => panic!("unexpected bytes for a slow client: {:?}", &buffer[..n]),
+            }
+        }
+        let cut_after = opened_at.elapsed();
+        assert!(
+            cut_after >= deadline,
+            "slow clients were not cut before the deadline ({cut_after:?})"
+        );
+        assert!(
+            cut_after < Duration::from_secs(4),
+            "slow clients were cut near the deadline, not the read timeout ({cut_after:?})"
+        );
+
+        // Their workers exit and release their share: a new client is served.
+        let released_deadline = Instant::now() + Duration::from_secs(5);
+        while ledger.lock().unwrap().len() > 0 {
+            assert!(Instant::now() < released_deadline, "slots were released");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let mut fresh = connect();
+        fresh
+            .write_all(b"GET /elsewhere HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .unwrap();
+        let mut response = Vec::new();
+        fresh.read_to_end(&mut response).unwrap();
+        assert!(String::from_utf8(response)
+            .unwrap()
+            .starts_with("HTTP/1.1 404 "));
+
+        shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+        accept_thread.join().unwrap();
     }
 
     #[derive(serde::Deserialize)]
@@ -2738,6 +3186,7 @@ non-ephemeral ports — a product regression, not a port race. Attempts: {failur
                         Arc::new(PlatformAdapterHub::default()),
                         None,
                         "http://127.0.0.1:17661/mobile".into(),
+                        Arc::new(std::sync::atomic::AtomicBool::new(false)),
                         Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     );
                 });


### PR DESCRIPTION
Fixes two findings from the 2026-09-04 server audit (F2 and the slow-client thread hold).

## A. Bounded unauthenticated connections (`crates/unpeel-serve/src/mobile.rs`)

The `/mobile` accept loop spawned one thread per connection with only a 30 s per-read timeout and no cap; 24 slow unauthenticated clients held 24 worker threads past the nominal timeout by pacing bytes.

- `ConnectionLedger` (new): global cap `MAX_CONNECTIONS = 64`, per-peer cap `MAX_CONNECTIONS_PER_PEER = 16`, pre-authentication deadline `PRE_AUTH_DEADLINE = 5 s` measured from accept. Pure bookkeeping, unit-tested without a socket.
- The accept loop admits through the ledger; the excess gets an immediate `503 Service Unavailable` + `Connection: close` written on the accept thread (`refuse_overloaded`) and never earns a worker.
- Every loop iteration runs `cut_expired_connections` (rate-limited to 100 ms): any connection whose worker has not seen a valid bearer token by the deadline gets `shutdown(Both)` on its control clone, which interrupts the worker's blocking read however slowly the client paced its bytes. The worker exits through its normal path and releases its slot.
- Test `slow_unauthenticated_connections_are_capped_and_cut_at_the_deadline`: N slow senders on a real listener, the (N+1)th is refused with 503 promptly, the slow ones are closed at the deadline, and a fresh client is served afterwards.

**Functions touched in `mobile.rs`** (for the TLS worker's merge): the accept loop inside `start_impl` (ledger admit/refuse before the worker spawn, `ledger.release` after `handle_connection` returns, `cut_expired_connections` at the top of each iteration); `handle_connection` gains one trailing parameter `authenticated: Arc<AtomicBool>` and stores `true` when `principal_for_bearer` succeeds; `respond` gains the 503 reason string; `remote_server_advertisement` (see B). New items: consts `PRE_AUTH_DEADLINE`/`MAX_CONNECTIONS`/`MAX_CONNECTIONS_PER_PEER`/`LEDGER_SWEEP_INTERVAL`, `ConnectionSlot`, `ConnectionLedger`, `refuse_overloaded`, `cut_expired_connections`, `remote_server_advertisement_at`. `read_request`, the TLS-relevant stream handling, `MobileServer`, and `stop` are untouched. The existing direct `handle_connection` call in `pairing_route_closes_keep_alive_socket_before_exact_rebind` passes the extra flag.

## B. Pid identity before treating a process as session-owned

Audit F2: "core said `NotOurs`; URL ownership still returned the stale session".

- `crates/unpeel-core/src/local_urls.rs` — `owning_session` (now `owning_session_in`) mapped every Running manifest's `pid` to its session with no identity check, so a dead session whose pid the OS recycled onto an unrelated process claimed that process's descendants as session-owned web servers, and `stop_server_for_url` would SIGTERM them. Only manifests with `manifest_pid_identity == Matches` count now (`Unknown`/`NotOurs` are not ownership); `LocalSiteServer` carries `pid_started_at` from resolve time and `verify_stop_target` re-checks pid + start time immediately before the signal.
- `crates/unpeel-serve/src/mobile.rs` — `remote_server_advertisement` relayed `remote.json`'s port and TLS fingerprint on a bare `kill(pid, 0)` even though `__remote__` records `pid_started_at`; it now requires `recorded_pid_identity == Matches`.
- `crates/unpeel-core/src/session_io.rs` — `HandedOverChild::kill` SIGKILLed a bare pid when a handoff carried no start time; it now signals only a verified child (liveness reporting for legacy handoffs is unchanged).
- `process_start_time_ms` is now `pub` (documented) so `unpeel-serve` can record start times.

Each site has a recycled-pid test: a live unrelated `sleep` under the recorded pid with a start time an hour off.

## Left out, deliberately

- Browser engine pids (`browser_mcp.rs`): the daemon `.pid` and Chrome's `SingletonLock` are written by the engine/Chrome, so there is no start time to record; every signal there is already argv-verified (`--user-data-dir <profile>` / `agent-browser`) before it is sent.
- `sessions.rs` display liveness already pairs `kill(pid,0)` with `manifest_pid_identity`; unchanged.

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace`: all green
- PTY matrix `run.sh mobile pairing approvals`: 73 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
