### PR TITLE
serve: /mobile over TLS; plaintext bearer tokens rejected

### DIFF
--- a/crates/unpeel-cli/tests/README.md
+++ b/crates/unpeel-cli/tests/README.md
@@ -76,7 +76,7 @@ Useful pieces:
 | `home.session(...)` | a hosted-session dir; `running=True` parks a real pid and binds a socket |
 | `home.marker(...)` | shared markers (`archived.json`, `title.json`, `read.json`) |
 | `home.pair_device()` / `home.reserve_mobile_port()` | a paired phone token and the published phone endpoint |
-| `mobile_request(port, path, token)` | an authenticated `/mobile/*` call |
+| `mobile_request(port, path, token)` | an authenticated `/mobile/*` call over TLS, pinned to the Host certificate the way a phone pins (`host_certificate_pin(home)`); `plaintext_mobile_request` is the cleartext shape the Host must refuse with 426 |
 | `McpClient(home, session_id)` | a `unpeel-host __mcp__` child speaking JSON-RPC for one caller Session (`tool_names`, `call`, `McpClient.text`) |
 
 Name checks as the behaviour a user would recognise ("archive falls back to

--- a/crates/unpeel-cli/tests/cases/mobile.py
+++ b/crates/unpeel-cli/tests/cases/mobile.py
@@ -1,28 +1,23 @@
 """Serve a paired phone with no desktop app in the Host tree: `unpeel serve`
 is the complete phone-facing Host."""
 
-import sys, os, base64, hashlib, json, time, urllib.error, urllib.parse, urllib.request
+import sys, os, base64, hashlib, json, time, urllib.parse
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from harness import run, mobile_request  # noqa: E402
+from harness import (  # noqa: E402
+    host_certificate_pin,
+    mobile_request,
+    plaintext_mobile_request,
+    run,
+)
 
 
 def mobile_binary_request(port, path, token, data, content_type, timeout=10):
-    request = urllib.request.Request(
-        f"http://127.0.0.1:{port}{path}", data=data, method="POST"
+    """A raw-bodied POST over the same pinned TLS transport as `mobile_request`."""
+    return mobile_request(
+        port, path, token, method="POST", timeout=timeout,
+        data=data, content_type=content_type,
     )
-    request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("Content-Type", content_type)
-    try:
-        response = urllib.request.urlopen(request, timeout=timeout)
-        return response.status, json.loads(response.read() or b"{}")
-    except urllib.error.HTTPError as error:
-        try:
-            return error.code, json.loads(error.read() or b"{}")
-        except ValueError:
-            return error.code, {}
-    except Exception as error:  # noqa: BLE001 - surfaced as a failed check
-        return 0, {"error": str(error)}
 
 
 def body(case):
@@ -148,6 +143,25 @@ def body(case):
         str({k: boot.get(k) for k in ("macID", "protocolVersion")}),
     )
     host_capabilities = set(boot.get("hostProtocol", {}).get("capabilities", []))
+    case.check(
+        "the direct endpoint is TLS with the pinned Host certificate",
+        "host.mobile.tls" in host_capabilities
+        and boot.get("remoteServerCertificateFingerprint") == host_certificate_pin(home)
+        and driver.status().get("directCertificateFingerprint") == host_certificate_pin(home),
+        str((sorted(host_capabilities), boot.get("remoteServerCertificateFingerprint"),
+             driver.status().get("directCertificateFingerprint"))),
+    )
+    case.check(
+        "bootstrap carries the Host version as the phone's fallback TLS signal",
+        boot.get("serverVersion") == driver.status().get("hostVersion"),
+        str((boot.get("serverVersion"), driver.status().get("hostVersion"))),
+    )
+    plain_status, plain = plaintext_mobile_request(port, "/mobile/bootstrap", token)
+    case.check(
+        "a paired token in the clear is refused, never authenticated",
+        plain_status == 426 and plain.get("error") == "use https",
+        str((plain_status, plain)),
+    )
     case.check(
         "bootstrap advertises the implemented headless Host operations",
         {

--- a/crates/unpeel-cli/tests/harness.py
+++ b/crates/unpeel-cli/tests/harness.py
@@ -20,6 +20,8 @@ Three things here are load-bearing and easy to get wrong:
 
 import fcntl
 import glob
+import hashlib
+import http.client
 import json
 import os
 import pty
@@ -28,6 +30,7 @@ import select
 import shutil
 import signal
 import socket
+import ssl
 import struct
 import subprocess
 import sys
@@ -286,6 +289,11 @@ def leftover_host_processes(home_root):
     return leftovers
 
 
+# Every private home this process built, oldest first; `host_certificate_pin`
+# finds the Host certificate a running serve wrote under one of them.
+_HOMES = []
+
+
 class Home:
     """A private `~/.unpeel` built from scratch."""
 
@@ -293,6 +301,7 @@ class Home:
         self.root = root
         self._hosts = []
         self._socks = []
+        _HOMES.append(self)
         os.makedirs(root, exist_ok=True)
         os.makedirs(self.path("app-sessions"), exist_ok=True)
         os.makedirs(self.path("mobile"), exist_ok=True)
@@ -1205,7 +1214,66 @@ def mcp_post(port, route, body, token=None, timeout=25):
         return 0, {"error": str(error)}
 
 
-def mobile_request(port, path, token, method="GET", body=None, timeout=10, headers=None):
+def host_certificate_pin(home=None):
+    """Hex SHA-256 of the Host certificate a private home serves, or None.
+
+    A paired phone pins this fingerprint (never a CA chain) for the direct
+    `/mobile` endpoint and the WSS streamer alike, so the harness pins the
+    same way: a Host serving any other certificate fails here. With no
+    `home`, the newest private home holding a certificate is used."""
+    homes = [home] if home is not None else list(reversed(_HOMES))
+    for candidate in homes:
+        try:
+            with open(candidate.path("remote", "tls", "cert.pem")) as handle:
+                pem = handle.read()
+        except OSError:
+            continue
+        return hashlib.sha256(ssl.PEM_cert_to_DER_cert(pem)).hexdigest()
+    return None
+
+
+def mobile_request(port, path, token, method="GET", body=None, timeout=10, headers=None,
+                   data=None, content_type="application/json", home=None):
+    """An authenticated `/mobile/*` call the way a paired phone makes it:
+    HTTPS on the direct port, pinned to the Host certificate. `body` is sent
+    as JSON; `data` sends raw bytes tagged `content_type`. Returns
+    `(status, json)`; a transport failure is `(0, {"error": ...})`."""
+    pin = host_certificate_pin(home)
+    if pin is None:
+        return 0, {"error": "no Host certificate under a private home yet"}
+    if data is not None:
+        payload = data
+    elif body is not None:
+        payload = json.dumps(body).encode()
+    else:
+        payload = None
+    request_headers = {"Authorization": f"Bearer {token}", "Content-Type": content_type}
+    request_headers.update(headers or {})
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE  # the fingerprint pin below is the trust decision
+    connection = http.client.HTTPSConnection("127.0.0.1", port, timeout=timeout, context=context)
+    try:
+        connection.connect()
+        served = hashlib.sha256(connection.sock.getpeercert(binary_form=True)).hexdigest()
+        if served != pin:
+            return 0, {"error": f"Host certificate pin mismatch: served {served}, pinned {pin}"}
+        connection.request(method, path, body=payload, headers=request_headers)
+        response = connection.getresponse()
+        raw = response.read()
+        try:
+            return response.status, json.loads(raw or b"{}")
+        except ValueError:
+            return response.status, {}
+    except Exception as error:  # noqa: BLE001 - surfaced as a failed check
+        return 0, {"error": str(error)}
+    finally:
+        connection.close()
+
+
+def plaintext_mobile_request(port, path, token, method="GET", body=None, timeout=10):
+    """The pre-TLS phone's request shape: cleartext HTTP carrying the bearer.
+    The Host must answer 426 without authenticating it."""
     request = urllib.request.Request(
         f"http://127.0.0.1:{port}{path}",
         data=json.dumps(body).encode() if body is not None else None,
@@ -1213,8 +1281,6 @@ def mobile_request(port, path, token, method="GET", body=None, timeout=10, heade
     )
     request.add_header("Authorization", f"Bearer {token}")
     request.add_header("Content-Type", "application/json")
-    for name, value in (headers or {}).items():
-        request.add_header(name, value)
     try:
         response = urllib.request.urlopen(request, timeout=timeout)
         return response.status, json.loads(response.read() or b"{}")

--- a/crates/unpeel-cli/tests/serve_command.rs
+++ b/crates/unpeel-cli/tests/serve_command.rs
@@ -97,7 +97,49 @@ fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
     condition()
 }
 
-fn mobile_request(port: u16, token: &str) -> (u16, serde_json::Value) {
+/// The pin a paired phone holds: the Host certificate under this workspace's
+/// `remote/tls`. Generating it here first means serve loads this exact file.
+fn host_certificate_fingerprint(home: &Path) -> String {
+    unpeel_core::remote_server::ensure_tls_material_in(&home.join("remote").join("tls"))
+        .expect("workspace Host certificate")
+        .fingerprint
+}
+
+/// A bearer request over the direct `/mobile` endpoint: TLS, pinned to the
+/// Host certificate, the way the phone speaks to it.
+fn mobile_request(home: &Path, port: u16, token: &str) -> (u16, serde_json::Value) {
+    use unpeel_core::rustls;
+    let config = Arc::new(unpeel_core::remote_attach::pinned_client_config(Some(
+        host_certificate_fingerprint(home),
+    )));
+    let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let connection = rustls::ClientConnection::new(config, name).unwrap();
+    let tcp = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    tcp.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let mut stream = rustls::StreamOwned::new(connection, tcp);
+    write!(
+        stream,
+        "GET /mobile/bootstrap HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
+    )
+    .unwrap();
+    stream.flush().unwrap();
+    let mut raw = Vec::new();
+    // The server closes without a TLS close_notify; keep what arrived.
+    let _ = stream.read_to_end(&mut raw);
+    let response = String::from_utf8(raw).unwrap();
+    let (head, body) = response.split_once("\r\n\r\n").unwrap();
+    let status = head
+        .split_whitespace()
+        .nth(1)
+        .unwrap()
+        .parse::<u16>()
+        .unwrap();
+    let body = serde_json::from_str(body).unwrap();
+    (status, body)
+}
+
+/// The pre-TLS phone's request shape: cleartext HTTP with the bearer.
+fn plaintext_mobile_request(port: u16, token: &str) -> (u16, serde_json::Value) {
     let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
@@ -117,8 +159,7 @@ fn mobile_request(port: u16, token: &str) -> (u16, serde_json::Value) {
         .unwrap()
         .parse::<u16>()
         .unwrap();
-    let body = serde_json::from_str(body).unwrap();
-    (status, body)
+    (status, serde_json::from_str(body).unwrap())
 }
 
 fn write_pairing_fixture(home: &Path, port: u16, token: &str) {
@@ -174,10 +215,33 @@ fn serve_runs_the_host_protocol_and_holds_one_workspace_lease() {
         "serve never published its Direct endpoint"
     );
 
-    let (status, bootstrap) = mobile_request(port, token);
+    let (status, bootstrap) = mobile_request(&home, port, token);
     assert_eq!(status, 200);
     assert_eq!(bootstrap["hostProtocol"]["majorVersion"], 1);
     assert!(bootstrap["hostProtocol"]["capabilities"].is_array());
+    assert!(
+        bootstrap["hostProtocol"]["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "host.mobile.tls"),
+        "bootstrap advertises the TLS direct endpoint: {bootstrap}"
+    );
+    assert_eq!(
+        bootstrap["serverVersion"],
+        env!("CARGO_PKG_VERSION"),
+        "bootstrap carries the Host version as the phone's fallback TLS signal"
+    );
+    assert_eq!(
+        bootstrap["remoteServerCertificateFingerprint"],
+        host_certificate_fingerprint(&home),
+        "bootstrap advertises the pinned Host certificate"
+    );
+
+    // The same paired token in the clear is refused before it is looked up.
+    let (status, body) = plaintext_mobile_request(port, token);
+    assert_eq!(status, 426, "{body}");
+    assert_eq!(body["error"], "use https");
 
     let duplicate = Command::new(env!("CARGO_BIN_EXE_unpeel"))
         .arg("serve")

--- a/crates/unpeel-core/src/controller_api.rs
+++ b/crates/unpeel-core/src/controller_api.rs
@@ -1204,6 +1204,7 @@ fn bootstrap_body(context: &HostBootstrapContext) -> Value {
         "protocolVersion": 1,
         "hostProtocol": context.protocol,
         "capturedAtUnixMs": current_timestamp_ms(),
+        "serverVersion": env!("CARGO_PKG_VERSION"),
     });
     if let (Some(object), Some(snapshot)) = (envelope.as_object_mut(), context.snapshot.as_object())
     {
@@ -1213,6 +1214,10 @@ fn bootstrap_body(context: &HostBootstrapContext) -> Value {
         // Router-owned metadata wins over anything cached in the UI snapshot.
         object.insert("protocolVersion".into(), 1.into());
         object.insert("capturedAtUnixMs".into(), current_timestamp_ms().into());
+        // Additive: the Host's crate version. A Controller without the
+        // capability list falls back to `serverVersion >= 0.5.3` to decide
+        // that the direct `/mobile` endpoint is TLS.
+        object.insert("serverVersion".into(), env!("CARGO_PKG_VERSION").into());
         object.insert(
             "hostProtocol".into(),
             serde_json::to_value(&context.protocol).unwrap_or(Value::Null),

--- a/crates/unpeel-core/src/controller_protocol.rs
+++ b/crates/unpeel-core/src/controller_protocol.rs
@@ -10,7 +10,7 @@
 use serde::{Deserialize, Serialize};
 
 pub const HOST_PROTOCOL_MAJOR: u16 = 1;
-pub const HOST_PROTOCOL_MINOR: u16 = 14;
+pub const HOST_PROTOCOL_MINOR: u16 = 15;
 
 pub const NATIVE_HOST_CAPABILITIES: &[&str] = &[
     "approval.answer",
@@ -22,6 +22,7 @@ pub const NATIVE_HOST_CAPABILITIES: &[&str] = &[
     "artifact.upload",
     "artifact.upload.resumable",
     "host.bootstrap",
+    "host.mobile.tls",
     "pairing.create",
     "pairing.invitation",
     "project.organization.set",
@@ -62,6 +63,7 @@ pub const HEADLESS_HOST_CAPABILITIES: &[&str] = &[
     "artifact.request_screenshot",
     "artifact.upload.resumable",
     "host.bootstrap",
+    "host.mobile.tls",
     "pairing.create",
     "pairing.invitation",
     "project.organization.set",

--- a/crates/unpeel-core/src/lib.rs
+++ b/crates/unpeel-core/src/lib.rs
@@ -91,6 +91,10 @@ pub mod relay_wire;
 pub mod remote_attach;
 #[cfg(feature = "native-host")]
 pub mod remote_server;
+/// The TLS stack behind the Host's pinned certificate. Re-exported so the
+/// serving crates and their tests use this one rustls, never a second copy.
+#[cfg(feature = "native-host")]
+pub use rustls;
 #[cfg(feature = "controller-core")]
 pub mod remote_session_backend;
 #[cfg(feature = "native-host")]

--- a/crates/unpeel-core/src/remote_attach.rs
+++ b/crates/unpeel-core/src/remote_attach.rs
@@ -483,11 +483,19 @@ fn request(
 }
 
 fn tls_config(fingerprint: Option<String>) -> Result<rustls::ClientConfig, String> {
+    Ok(pinned_client_config(fingerprint))
+}
+
+/// A rustls client config that pins the Host certificate to `fingerprint`
+/// (lowercase hex SHA-256 of the leaf DER, the value pairing and bootstrap
+/// advertise) instead of a CA chain. `None` accepts any certificate: loopback
+/// tests and unpinned dev use only.
+pub fn pinned_client_config(fingerprint: Option<String>) -> rustls::ClientConfig {
     let verifier = Arc::new(FingerprintVerifier { fingerprint });
-    Ok(rustls::ClientConfig::builder()
+    rustls::ClientConfig::builder()
         .dangerous()
         .with_custom_certificate_verifier(verifier)
-        .with_no_client_auth())
+        .with_no_client_auth()
 }
 
 /// Pins the server certificate to a SHA-256 fingerprint (the one the remote

--- a/crates/unpeel-core/src/remote_server.rs
+++ b/crates/unpeel-core/src/remote_server.rs
@@ -185,11 +185,17 @@ pub struct TlsMaterial {
 }
 
 /// Load the persisted self-signed certificate, generating one on first use.
+///
+/// This is the one Host certificate every pinned transport serves — the
+/// `__remote__` WSS streamer and the direct `/mobile` listener — so a
+/// Controller keeps a single fingerprint pin for both.
 pub fn ensure_tls_material() -> Result<TlsMaterial, String> {
     ensure_tls_material_in(&tls_dir())
 }
 
-pub(crate) fn ensure_tls_material_in(dir: &std::path::Path) -> Result<TlsMaterial, String> {
+/// [`ensure_tls_material`] against an explicit directory (tests and tools
+/// that address a specific `UNPEEL_HOME`).
+pub fn ensure_tls_material_in(dir: &std::path::Path) -> Result<TlsMaterial, String> {
     let cert_path = dir.join("cert.pem");
     let key_path = dir.join("key.pem");
     if cert_path.exists() && key_path.exists() {
@@ -250,7 +256,8 @@ fn write_private(path: &std::path::Path, data: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-fn build_tls_config(material: TlsMaterial) -> Result<Arc<rustls::ServerConfig>, String> {
+/// A rustls server config that serves the Host certificate.
+pub fn build_tls_config(material: TlsMaterial) -> Result<Arc<rustls::ServerConfig>, String> {
     let config = rustls::ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(material.certs, material.key)

--- a/crates/unpeel-host/tests/local_gateway_process.rs
+++ b/crates/unpeel-host/tests/local_gateway_process.rs
@@ -129,6 +129,45 @@ fn recv_platform_callbacks(
     found
 }
 
+/// A bearer request over the worker's direct `/mobile` endpoint: TLS pinned
+/// to the workspace's Host certificate, the way a paired phone speaks to it.
+fn direct_tls_request(
+    home: &Path,
+    port: u16,
+    method: &str,
+    path: &str,
+    bearer: &str,
+    body: &[u8],
+) -> Vec<u8> {
+    use unpeel_core::rustls;
+    let fingerprint =
+        unpeel_core::remote_server::ensure_tls_material_in(&home.join("remote").join("tls"))
+            .expect("workspace Host certificate")
+            .fingerprint;
+    let config = Arc::new(unpeel_core::remote_attach::pinned_client_config(Some(
+        fingerprint,
+    )));
+    let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let connection = rustls::ClientConnection::new(config, name).unwrap();
+    let tcp = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    tcp.set_read_timeout(Some(Duration::from_secs(30))).unwrap();
+    let mut stream = rustls::StreamOwned::new(connection, tcp);
+    write!(
+        stream,
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {bearer}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .unwrap();
+    stream.write_all(body).unwrap();
+    stream.flush().unwrap();
+    let mut response = Vec::new();
+    // The server closes without a TLS close_notify; keep what arrived.
+    let _ = stream.read_to_end(&mut response);
+    response
+}
+
+/// A cleartext request to the worker's loopback hook port (platform and App
+/// routes), which is not the paired-device transport.
 fn direct_mobile_request(
     port: u16,
     method: &str,
@@ -716,7 +755,8 @@ fn unified_worker_advertises_and_withdraws_connection_scoped_platform_adapter() 
     let request = recv_platform_callback(&captured_rx, "app.open-in-editor");
     assert!(request.contains("open-me.txt"));
 
-    let thumbnail = direct_mobile_request(
+    let thumbnail = direct_tls_request(
+        &fixture.host_home,
         direct_port,
         "GET",
         "/mobile/artifact?session_id=s1&kind=screenshots&name=shot.png&offset=0&limit=3&max_dim=128",
@@ -734,7 +774,8 @@ fn unified_worker_advertises_and_withdraws_connection_scoped_platform_adapter() 
     assert!(request.contains("\"max_dim\":\"128\""));
     #[cfg(target_os = "macos")]
     {
-        let direct_bootstrap = direct_mobile_request(
+        let direct_bootstrap = direct_tls_request(
+            &fixture.host_home,
             direct_port,
             "GET",
             "/mobile/bootstrap",
@@ -761,7 +802,8 @@ fn unified_worker_advertises_and_withdraws_connection_scoped_platform_adapter() 
             true
         );
     }
-    let direct_color = direct_mobile_request(
+    let direct_color = direct_tls_request(
+        &fixture.host_home,
         direct_port,
         "POST",
         "/mobile/project-organization",
@@ -777,7 +819,8 @@ fn unified_worker_advertises_and_withdraws_connection_scoped_platform_adapter() 
     assert!(request.contains("\"projectID\":\"p1\""));
     assert!(request.contains("\"colorID\":\"teal\""));
 
-    let push = direct_mobile_request(
+    let push = direct_tls_request(
+        &fixture.host_home,
         direct_port,
         "POST",
         "/mobile/push-token",
@@ -793,7 +836,8 @@ fn unified_worker_advertises_and_withdraws_connection_scoped_platform_adapter() 
     assert!(request.contains("\"operation\":\"push.register\""));
     assert!(request.contains("\"deviceID\":\"phone-process\""));
 
-    let relay = direct_mobile_request(
+    let relay = direct_tls_request(
+        &fixture.host_home,
         direct_port,
         "GET",
         "/mobile/relay-credentials",

--- a/crates/unpeel-host/tests/remote_streamer_supervision_process.rs
+++ b/crates/unpeel-host/tests/remote_streamer_supervision_process.rs
@@ -16,6 +16,7 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 struct ServeProcess {
@@ -253,10 +254,11 @@ fn process_alive(pid: u32) -> bool {
 /// bound it (and a respawned streamer/worker rebinds it): connect with a
 /// bounded wait for the listener instead of an immediate `connect().unwrap()`
 /// that once failed in a solo staging run.
-fn bootstrap(port: u16, token: &str) -> (u16, serde_json::Value) {
+fn bootstrap(home: &Path, port: u16, token: &str) -> (u16, serde_json::Value) {
+    use unpeel_core::rustls;
     let deadline = Instant::now() + Duration::from_secs(60);
     let mut last_error = None;
-    let mut stream = loop {
+    let tcp = loop {
         match TcpStream::connect(("127.0.0.1", port)) {
             Ok(stream) => break stream,
             Err(error) if Instant::now() < deadline => {
@@ -268,16 +270,28 @@ fn bootstrap(port: u16, token: &str) -> (u16, serde_json::Value) {
             ),
         }
     };
-    stream
-        .set_read_timeout(Some(Duration::from_secs(30)))
-        .unwrap();
+    tcp.set_read_timeout(Some(Duration::from_secs(30))).unwrap();
+    // The direct endpoint is TLS, pinned to the workspace's Host certificate
+    // — the same file the worker's streamer serves.
+    let fingerprint =
+        unpeel_core::remote_server::ensure_tls_material_in(&home.join("remote").join("tls"))
+            .expect("workspace Host certificate")
+            .fingerprint;
+    let config = Arc::new(unpeel_core::remote_attach::pinned_client_config(Some(
+        fingerprint,
+    )));
+    let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let connection = rustls::ClientConnection::new(config, name).unwrap();
+    let mut stream = rustls::StreamOwned::new(connection, tcp);
     write!(
         stream,
         "GET /mobile/bootstrap HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"
     )
     .unwrap();
+    stream.flush().unwrap();
     let mut raw = Vec::new();
-    stream.read_to_end(&mut raw).unwrap();
+    // The server closes without a TLS close_notify; keep what arrived.
+    let _ = stream.read_to_end(&mut raw);
     let response = String::from_utf8(raw).unwrap();
     let (head, body) = response.split_once("\r\n\r\n").unwrap();
     let status = head
@@ -289,8 +303,8 @@ fn bootstrap(port: u16, token: &str) -> (u16, serde_json::Value) {
     (status, serde_json::from_str(body).unwrap())
 }
 
-fn advertised_remote_port(port: u16, token: &str) -> Option<u64> {
-    let (status, body) = bootstrap(port, token);
+fn advertised_remote_port(home: &Path, port: u16, token: &str) -> Option<u64> {
+    let (status, body) = bootstrap(home, port, token);
     assert_eq!(status, 200, "bootstrap failed: {body}");
     body.get("remoteServerPort").and_then(|v| v.as_u64())
 }
@@ -326,7 +340,7 @@ fn worker_respawns_a_killed_streamer_without_a_service_restart() {
     assert_ne!(first_pid, process.child.id());
     assert!(
         wait_until(Duration::from_secs(60), || {
-            advertised_remote_port(port, token) == Some(u64::from(first_port))
+            advertised_remote_port(&home, port, token) == Some(u64::from(first_port))
         }),
         "bootstrap never advertised the first streamer"
     );
@@ -371,7 +385,7 @@ fn worker_respawns_a_killed_streamer_without_a_service_restart() {
     );
     assert!(
         wait_until(Duration::from_secs(60), || {
-            advertised_remote_port(port, token) == Some(u64::from(second_port))
+            advertised_remote_port(&home, port, token) == Some(u64::from(second_port))
         }),
         "bootstrap never advertised the respawned streamer"
     );
@@ -461,7 +475,7 @@ fn crash_looping_streamer_hits_the_ceiling_and_retries_on_pairing_change() {
     assert_eq!(launch_count(&counter), launches_at_ceiling);
     assert_eq!(streamer_state(&home).as_deref(), Some("gaveUp"));
     assert!(
-        advertised_remote_port(port, token).is_none(),
+        advertised_remote_port(&home, port, token).is_none(),
         "a dead streamer must not be advertised"
     );
     assert!(trace_log(&home).contains("giving up until pairing changes"));

--- a/crates/unpeel-serve/src/driver.rs
+++ b/crates/unpeel-serve/src/driver.rs
@@ -232,6 +232,10 @@ struct ServeStatus<'a> {
     local_socket: &'a Path,
     #[serde(skip_serializing_if = "Option::is_none")]
     direct_port: Option<u16>,
+    /// Lowercase hex SHA-256 of the Host certificate the direct `/mobile`
+    /// listener serves (additive; the same pin as the WSS streamer).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    direct_certificate_fingerprint: Option<String>,
     link_running: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     terminal_streamer: Option<crate::remote_streamer::StreamerStatus>,
@@ -1869,6 +1873,10 @@ impl HostRuntime {
             hook_port: self.hook_port,
             local_socket: self.local_gateway.path(),
             direct_port: self.direct_port(),
+            direct_certificate_fingerprint: self
+                .mobile_server
+                .as_ref()
+                .map(|server| server.certificate_fingerprint.clone()),
             link_running: self.relay_uplink.is_some(),
             terminal_streamer: self
                 .mobile_server
@@ -2162,6 +2170,7 @@ mod tests {
             hook_port: 41000,
             local_socket: Path::new("/tmp/workspace/host.sock"),
             direct_port: Some(42000),
+            direct_certificate_fingerprint: Some("ab".repeat(32)),
             link_running: true,
             terminal_streamer: Some(crate::remote_streamer::StreamerStatus {
                 state: "live",
@@ -2211,6 +2220,7 @@ mod tests {
         assert_eq!(value["hookPort"], 41000);
         assert_eq!(value["localSocket"], "/tmp/workspace/host.sock");
         assert_eq!(value["directPort"], 42000);
+        assert_eq!(value["directCertificateFingerprint"], "ab".repeat(32));
         assert_eq!(value["linkRunning"], true);
     }
 }

--- a/crates/unpeel-serve/src/mobile.rs
+++ b/crates/unpeel-serve/src/mobile.rs
@@ -1,8 +1,17 @@
 //! App-less `/mobile/*` server: the same wire contract as the native
 //! `MobileRemoteServer.swift`, so an already-paired phone keeps working when
-//! only the TUI runs. Plain HTTP/1.1, Bearer auth against the shared
-//! `~/.unpeel/mobile/devices.json` token hashes, JSON keys in the Swift
-//! dialect (camelCase with capital-ID suffixes, optionals omitted).
+//! only the TUI runs. HTTP/1.1 over TLS with the Host certificate (the same
+//! pinned certificate the `__remote__` WSS streamer serves), Bearer auth
+//! against the shared `~/.unpeel/mobile/devices.json` token hashes, JSON keys
+//! in the Swift dialect (camelCase with capital-ID suffixes, optionals
+//! omitted).
+//!
+//! Transport rule: one port, TLS by default, plaintext tolerated only for the
+//! pairing exchange, which is sealed at the application layer. A connection is
+//! classified by its first byte (`0x16` is a TLS ClientHello). A plaintext
+//! request that presents any credential is refused with `426 Upgrade Required`
+//! and `"use https"` *before* the token is looked up: a paired device's
+//! long-lived bearer never authenticates over a cleartext connection.
 //!
 //! Single-owner rule: the exact persisted listener is the phone + Link lease.
 //! A TUI yields that lease only to a validated native sidebar, then retries it
@@ -28,10 +37,153 @@ use unpeel_core::controller_api::{
     ControllerEffects, ControllerPrincipal, ControllerRequest, HostBootstrapContext,
     HostCreateContext, HostCreateProject, HostRouteContext,
 };
+use unpeel_core::rustls;
 
 use crate::platform_adapter::{PlatformAdapterError, PlatformAdapterHub};
 
 const IO_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How a connection reached the listener, decided from its first byte.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Transport {
+    /// A TLS ClientHello: served over the Host certificate.
+    Tls,
+    /// Cleartext HTTP/1.1: only the sealed pairing exchange belongs here.
+    Plaintext,
+}
+
+/// The first byte of a TLS record is its content type; a ClientHello is a
+/// handshake record (`0x16`). No HTTP method token starts with that byte.
+pub(crate) fn transport_for_first_byte(first: u8) -> Transport {
+    if first == 0x16 {
+        Transport::Tls
+    } else {
+        Transport::Plaintext
+    }
+}
+
+/// The plaintext gate, evaluated before any credential is looked up. A
+/// cleartext request that presents an `Authorization` header ends here with
+/// `426 Upgrade Required` and a body naming the fix; the token is never
+/// hashed, compared, or authenticated. TLS requests pass through untouched.
+pub(crate) fn plaintext_credential_rejection(
+    transport: Transport,
+    request: &Request,
+) -> Option<(u16, String)> {
+    if transport == Transport::Tls || !request.headers.contains_key("authorization") {
+        return None;
+    }
+    Some((
+        426,
+        serde_json::json!({
+            "error": "use https",
+            "detail": "the direct /mobile endpoint serves TLS with the Host \
+                       certificate; a bearer token is never accepted over \
+                       plaintext",
+        })
+        .to_string(),
+    ))
+}
+
+/// One accepted socket, wrapped for its transport. Both arms are blocking
+/// `std` streams, so the request loop is transport-agnostic.
+enum MobileStream {
+    Plaintext(TcpStream),
+    Tls(Box<rustls::StreamOwned<rustls::ServerConnection, TcpStream>>),
+}
+
+impl Read for MobileStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            MobileStream::Plaintext(stream) => stream.read(buf),
+            MobileStream::Tls(stream) => stream.read(buf),
+        }
+    }
+}
+
+impl Write for MobileStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            MobileStream::Plaintext(stream) => stream.write(buf),
+            MobileStream::Tls(stream) => stream.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            MobileStream::Plaintext(stream) => stream.flush(),
+            MobileStream::Tls(stream) => stream.flush(),
+        }
+    }
+}
+
+/// Classify an accepted socket by peeking (`MSG_PEEK`) its first byte, so the
+/// TLS layer still reads the whole ClientHello itself. `None` when the peer
+/// hung up or the read timeout elapsed before sending anything.
+fn accept_transport(
+    stream: TcpStream,
+    tls: &Arc<rustls::ServerConfig>,
+) -> Option<(Transport, MobileStream)> {
+    let mut first = [0u8; 1];
+    if !matches!(stream.peek(&mut first), Ok(1)) {
+        return None;
+    }
+    match transport_for_first_byte(first[0]) {
+        Transport::Tls => {
+            let connection = rustls::ServerConnection::new(Arc::clone(tls)).ok()?;
+            Some((
+                Transport::Tls,
+                MobileStream::Tls(Box::new(rustls::StreamOwned::new(connection, stream))),
+            ))
+        }
+        Transport::Plaintext => Some((Transport::Plaintext, MobileStream::Plaintext(stream))),
+    }
+}
+
+/// The Host certificate this listener serves, as loaded by `start_impl`.
+/// Bootstrap and the sealed pairing response advertise it so a Controller
+/// pins one fingerprint for `/mobile` and the WSS streamer alike.
+static DIRECT_CERTIFICATE_FINGERPRINT: std::sync::OnceLock<Mutex<Option<String>>> =
+    std::sync::OnceLock::new();
+
+fn remember_direct_certificate_fingerprint(fingerprint: &str) {
+    if let Ok(mut guard) = DIRECT_CERTIFICATE_FINGERPRINT
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *guard = Some(fingerprint.to_owned());
+    }
+}
+
+/// Lowercase hex SHA-256 of the certificate the direct listener serves, once
+/// a listener has started in this process.
+pub(crate) fn direct_certificate_fingerprint() -> Option<String> {
+    DIRECT_CERTIFICATE_FINGERPRINT
+        .get()
+        .and_then(|cell| cell.lock().ok())
+        .and_then(|guard| guard.clone())
+}
+
+/// Load the Host certificate and build the listener's TLS config. Failing
+/// closed here (no listener) beats a cleartext-only listener that would refuse
+/// every paired device anyway.
+fn direct_tls_config() -> Option<(Arc<rustls::ServerConfig>, String)> {
+    let material = match unpeel_core::remote_server::ensure_tls_material() {
+        Ok(material) => material,
+        Err(error) => {
+            crate::tracelog::trace("mobile-tls", &format!("certificate unavailable: {error}"));
+            return None;
+        }
+    };
+    let fingerprint = material.fingerprint.clone();
+    match unpeel_core::remote_server::build_tls_config(material) {
+        Ok(config) => Some((config, fingerprint)),
+        Err(error) => {
+            crate::tracelog::trace("mobile-tls", &format!("tls config failed: {error}"));
+            None
+        }
+    }
+}
 const MAX_BODY: usize = 4 * 1024 * 1024;
 /// Wall-clock budget for a connection to authenticate, measured from accept.
 /// The per-read `IO_TIMEOUT` alone lets a slow sender hold a worker thread
@@ -125,6 +277,9 @@ fn valid_native_artifact_chunk(value: &serde_json::Value, query: &HashMap<String
 
 pub struct MobileServer {
     pub port: u16,
+    /// Lowercase hex SHA-256 of the Host certificate this listener serves;
+    /// the pin a Controller holds for `/mobile` and the WSS streamer alike.
+    pub certificate_fingerprint: String,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
     bonjour: Arc<Mutex<Option<std::process::Child>>>,
     remote: Arc<Mutex<crate::remote_streamer::RemoteStreamer>>,
@@ -810,7 +965,7 @@ pub(crate) struct Request {
     pub(crate) keep_alive: bool,
 }
 
-fn read_request(stream: &mut TcpStream, pending: &mut Vec<u8>) -> Option<Request> {
+fn read_request<S: Read>(stream: &mut S, pending: &mut Vec<u8>) -> Option<Request> {
     let header_end = loop {
         if let Some(pos) = pending.windows(4).position(|w| w == b"\r\n\r\n") {
             break pos + 4;
@@ -912,7 +1067,18 @@ fn urldecode(s: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
-fn respond(stream: &mut TcpStream, status: u16, body: &str, keep_alive: bool) -> bool {
+fn respond<S: Write>(stream: &mut S, status: u16, body: &str, keep_alive: bool) -> bool {
+    respond_with(stream, status, "", body, keep_alive)
+}
+
+/// `respond` with extra raw header lines (each `\r\n`-terminated).
+fn respond_with<S: Write>(
+    stream: &mut S,
+    status: u16,
+    extra_headers: &str,
+    body: &str,
+    keep_alive: bool,
+) -> bool {
     let reason = match status {
         200 => "OK",
         400 => "Bad Request",
@@ -920,6 +1086,7 @@ fn respond(stream: &mut TcpStream, status: u16, body: &str, keep_alive: bool) ->
         404 => "Not Found",
         409 => "Conflict",
         405 => "Method Not Allowed",
+        426 => "Upgrade Required",
         500 => "Internal Server Error",
         501 => "Not Implemented",
         503 => "Service Unavailable",
@@ -929,11 +1096,17 @@ fn respond(stream: &mut TcpStream, status: u16, body: &str, keep_alive: bool) ->
     let connection = if keep_alive { "keep-alive" } else { "close" };
     write!(
         stream,
-        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nCache-Control: no-store\r\nContent-Length: {}\r\nConnection: {connection}\r\n\r\n{body}",
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nCache-Control: no-store\r\n{extra_headers}Content-Length: {}\r\nConnection: {connection}\r\n\r\n{body}",
         body.len()
     )
     .and_then(|_| stream.flush())
     .is_ok()
+}
+
+/// The plaintext-credential refusal: `426` names TLS as the upgrade and closes
+/// the connection so a client cannot keep streaming its token in the clear.
+fn respond_upgrade_required<S: Write>(stream: &mut S, body: &str) -> bool {
+    respond_with(stream, 426, "Upgrade: TLS/1.3, HTTP/1.1\r\n", body, false)
 }
 
 fn error_body(message: &str) -> String {
@@ -1292,7 +1465,11 @@ fn handle_with_effects(
             .map(|value| value.trim().to_owned())
             .ok();
         context.remote_server_port = port.and_then(|value| u16::try_from(value).ok());
-        context.remote_server_certificate_fingerprint = fingerprint;
+        // One certificate serves both pinned transports, so the fingerprint
+        // is advertised whenever the direct listener has it — a Controller
+        // pins `/mobile` even while the streamer is down.
+        context.remote_server_certificate_fingerprint =
+            fingerprint.or_else(direct_certificate_fingerprint);
         context.pending_approvals = approvals.list_json();
         platform_adapters.decorate_protocol(&mut context.protocol);
         Some(HostRouteContext {
@@ -2136,7 +2313,8 @@ fn cut_expired_connections(
 
 #[allow(clippy::too_many_arguments)]
 fn handle_connection(
-    mut stream: TcpStream,
+    stream: TcpStream,
+    tls: Arc<rustls::ServerConfig>,
     snapshot: SharedSnapshot,
     mark_read: Sender<String>,
     hook_port: Option<u16>,
@@ -2151,6 +2329,11 @@ fn handle_connection(
 ) {
     let _ = stream.set_read_timeout(Some(IO_TIMEOUT));
     let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    // The first byte decides the transport; the TLS handshake itself happens
+    // on the first read of the wrapped stream.
+    let Some((transport, mut stream)) = accept_transport(stream, &tls) else {
+        return;
+    };
     let mut pending = Vec::new();
     for _ in 0..1000 {
         if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
@@ -2160,6 +2343,12 @@ fn handle_connection(
             return;
         };
         let keep = request.keep_alive;
+        // Before routing, before any token lookup: cleartext never carries a
+        // credential past this point.
+        if let Some((_, body)) = plaintext_credential_rejection(transport, &request) {
+            respond_upgrade_required(&mut stream, &body);
+            return;
+        }
         if !request.path.starts_with("/mobile/") {
             respond(&mut stream, 404, &error_body("not found"), keep);
         } else if request.path == "/mobile/pair" {
@@ -2366,6 +2555,12 @@ fn start_impl(
         headless_persisted,
     )?;
     let port = listener.local_addr().ok()?.port();
+    // The Host certificate is the same material the `__remote__` streamer
+    // serves, so a Controller's existing pin covers this listener. Without it
+    // there is no listener: a cleartext-only server would refuse every paired
+    // device anyway (see `plaintext_credential_rejection`).
+    let (tls, certificate_fingerprint) = direct_tls_config()?;
+    remember_direct_certificate_fingerprint(&certificate_fingerprint);
     let direct_endpoint: Arc<str> =
         format!("http://{}:{port}/mobile", preferred_lan_address()).into();
     if handoff.is_none()
@@ -2481,6 +2676,7 @@ fn start_impl(
                     refuse_overloaded(stream);
                     continue;
                 };
+                let tls = Arc::clone(&tls);
                 let snapshot = Arc::clone(&snapshot);
                 let mark_read = mark_read.clone();
                 let resizes = Arc::clone(&resizes);
@@ -2500,6 +2696,7 @@ fn start_impl(
                 let worker = std::thread::spawn(move || {
                     handle_connection(
                         stream,
+                        tls,
                         snapshot,
                         mark_read,
                         hook_port,
@@ -2540,6 +2737,7 @@ fn start_impl(
     });
     Some(MobileServer {
         port,
+        certificate_fingerprint,
         shutdown,
         bonjour,
         remote,
@@ -2717,6 +2915,7 @@ mod tests {
                             let (mark_read, _receiver) = std::sync::mpsc::channel();
                             handle_connection(
                                 stream,
+                                test_tls_config(),
                                 Arc::new(Mutex::new(crate::sessions::MobileSnapshot::default())),
                                 mark_read,
                                 None,
@@ -2754,12 +2953,20 @@ mod tests {
                 .unwrap();
             client
         };
-        // N slow senders: a partial request head, then silence.
+        // N slow senders, then silence: half a partial plaintext request
+        // head, half the first bytes of a TLS ClientHello — a stalled TLS
+        // handshake sits under the same pre-auth deadline as a stalled
+        // request.
         let opened_at = Instant::now();
         let mut slow: Vec<TcpStream> = (0..CAP)
-            .map(|_| {
+            .map(|index| {
                 let mut client = connect();
-                client.write_all(b"GET /mob").unwrap();
+                let partial: &[u8] = if index % 2 == 0 {
+                    b"GET /mob"
+                } else {
+                    b"\x16\x03\x01\x00"
+                };
+                client.write_all(partial).unwrap();
                 client
             })
             .collect();
@@ -2822,6 +3029,248 @@ mod tests {
 
         shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
         accept_thread.join().unwrap();
+    }
+
+    /// A Host certificate generated into a scratch directory through the real
+    /// material loader — never this process's `~/.unpeel`. Returns the server
+    /// config and the fingerprint a Controller would pin.
+    fn test_tls_material() -> (Arc<rustls::ServerConfig>, String) {
+        let dir = scratch_dir("tls");
+        let material = unpeel_core::remote_server::ensure_tls_material_in(&dir)
+            .expect("scratch Host certificate");
+        let fingerprint = material.fingerprint.clone();
+        let config =
+            unpeel_core::remote_server::build_tls_config(material).expect("scratch TLS config");
+        let _ = std::fs::remove_dir_all(dir);
+        (config, fingerprint)
+    }
+
+    fn test_tls_config() -> Arc<rustls::ServerConfig> {
+        test_tls_material().0
+    }
+
+    /// Accept one connection and run it through the production handler.
+    fn serve_one_connection(
+        listener: TcpListener,
+        tls: Arc<rustls::ServerConfig>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let snapshot = Arc::new(Mutex::new(crate::sessions::MobileSnapshot::default()));
+            let (mark_read, _receiver) = std::sync::mpsc::channel();
+            handle_connection(
+                stream,
+                tls,
+                snapshot,
+                mark_read,
+                None,
+                Arc::new(Mutex::new(HashMap::new())),
+                Arc::new(crate::approvals::ApprovalHub::default()),
+                Arc::new(crate::pairing::PairingWindow::default()),
+                Arc::new(PlatformAdapterHub::default()),
+                None,
+                "http://127.0.0.1:17661/mobile".into(),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            );
+        })
+    }
+
+    /// A Controller-side TLS stream pinned the way the phone pins: to the
+    /// certificate fingerprint, not a CA chain.
+    fn tls_client(
+        port: u16,
+        fingerprint: Option<String>,
+    ) -> rustls::StreamOwned<rustls::ClientConnection, TcpStream> {
+        let config = Arc::new(unpeel_core::remote_attach::pinned_client_config(
+            fingerprint,
+        ));
+        let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let connection = rustls::ClientConnection::new(config, name).unwrap();
+        let tcp = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        tcp.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        rustls::StreamOwned::new(connection, tcp)
+    }
+
+    /// Send one request, read until the server closes: (status, head, body).
+    fn http_exchange<S: Read + Write>(stream: &mut S, request: &str) -> (u16, String, String) {
+        // A refused certificate surfaces here: the handshake runs on the
+        // first write and fails before any HTTP byte crosses.
+        if let Err(error) = stream
+            .write_all(request.as_bytes())
+            .and_then(|_| stream.flush())
+        {
+            return (0, String::new(), format!("write failed: {error}"));
+        }
+        let mut raw = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => raw.extend_from_slice(&chunk[..n]),
+            }
+        }
+        let text = String::from_utf8_lossy(&raw).into_owned();
+        let (head, body) = text.split_once("\r\n\r\n").unwrap_or((text.as_str(), ""));
+        let status = head
+            .split_whitespace()
+            .nth(1)
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+        (status, head.to_owned(), body.to_owned())
+    }
+
+    fn request_with_headers(path: &str, headers: &[(&str, &str)]) -> Request {
+        Request {
+            request_id: None,
+            method: "GET".into(),
+            path: path.into(),
+            query: HashMap::new(),
+            headers: headers
+                .iter()
+                .map(|(name, value)| (name.to_string(), value.to_string()))
+                .collect(),
+            body: Vec::new(),
+            keep_alive: true,
+        }
+    }
+
+    #[test]
+    fn first_byte_classifies_the_transport() {
+        assert_eq!(transport_for_first_byte(0x16), Transport::Tls);
+        for byte in [b'G', b'P', b'H', b'O', b'D', 0x00, 0xff] {
+            assert_eq!(transport_for_first_byte(byte), Transport::Plaintext);
+        }
+    }
+
+    #[test]
+    fn plaintext_gate_refuses_credentials_and_passes_tls_through() {
+        let bearer = [("authorization", "Bearer phone-token-1")];
+        let (status, body) = plaintext_credential_rejection(
+            Transport::Plaintext,
+            &request_with_headers("/mobile/bootstrap", &bearer),
+        )
+        .expect("plaintext + bearer is refused");
+        assert_eq!(status, 426);
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["error"], "use https");
+
+        // Any credential shape, any route — even pairing — is refused in the
+        // clear; the pairing exchange itself carries no Authorization header.
+        assert!(plaintext_credential_rejection(
+            Transport::Plaintext,
+            &request_with_headers("/mobile/pair", &[("authorization", "Basic abc")]),
+        )
+        .is_some());
+
+        // TLS carries the bearer on to authentication.
+        assert!(plaintext_credential_rejection(
+            Transport::Tls,
+            &request_with_headers("/mobile/bootstrap", &bearer),
+        )
+        .is_none());
+        // Unauthenticated plaintext requests keep their existing answers
+        // (the pairing route, or 401/404 further down).
+        assert!(plaintext_credential_rejection(
+            Transport::Plaintext,
+            &request_with_headers("/mobile/pair", &[]),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn plaintext_bearer_is_refused_before_authentication() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handler = serve_one_connection(listener, test_tls_config());
+
+        let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (status, head, body) = http_exchange(
+            &mut client,
+            "GET /mobile/bootstrap HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer phone-token-1\r\nConnection: keep-alive\r\n\r\n",
+        );
+        handler.join().unwrap();
+
+        // 426, never 401: the token was refused for its transport, not looked
+        // up and found unknown.
+        assert_eq!(status, 426, "{head}\n{body}");
+        assert!(head.contains("Upgrade: TLS/1.3"), "{head}");
+        assert!(head.contains("Connection: close"), "{head}");
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["error"], "use https");
+    }
+
+    #[test]
+    fn tls_carries_the_bearer_past_the_plaintext_gate() {
+        let (tls, fingerprint) = test_tls_material();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handler = serve_one_connection(listener, tls);
+
+        // Pinned to the served certificate, exactly as a paired phone pins.
+        // A non-/mobile path answers 404 only after the gate let the bearer
+        // through; the same request in the clear ends in 426 above. (The
+        // paired-token lookup itself is exercised by the process tests with
+        // a private UNPEEL_HOME.)
+        let mut client = tls_client(port, Some(fingerprint));
+        let (status, head, body) = http_exchange(
+            &mut client,
+            "GET /not-mobile HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer phone-token-1\r\nConnection: close\r\n\r\n",
+        );
+        handler.join().unwrap();
+        assert_eq!(status, 404, "{head}\n{body}");
+        assert!(body.contains("not found"), "{body}");
+    }
+
+    #[test]
+    fn pairing_route_answers_on_both_transports() {
+        let (tls, fingerprint) = test_tls_material();
+        let pair = "POST /mobile/pair HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}";
+
+        // Over TLS: the sealed exchange reaches the pairing window.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handler = serve_one_connection(listener, Arc::clone(&tls));
+        let mut client = tls_client(port, Some(fingerprint));
+        let (status, _, body) = http_exchange(&mut client, pair);
+        handler.join().unwrap();
+        assert_eq!(status, 401, "{body}");
+        assert!(body.contains("pairing is not active"), "{body}");
+
+        // In the clear: the QR-code pairing client still reaches it, since
+        // the exchange is sealed at the application layer.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handler = serve_one_connection(listener, tls);
+        let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (status, _, body) = http_exchange(&mut client, pair);
+        handler.join().unwrap();
+        assert_eq!(status, 401, "{body}");
+        assert!(body.contains("pairing is not active"), "{body}");
+    }
+
+    #[test]
+    fn a_wrong_pin_never_completes_the_handshake() {
+        let (tls, _) = test_tls_material();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handler = serve_one_connection(listener, tls);
+        let mut client = tls_client(port, Some("00".repeat(32)));
+        let (status, _, body) = http_exchange(
+            &mut client,
+            "GET /mobile/pair HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        );
+        handler.join().unwrap();
+        assert_eq!(
+            status, 0,
+            "no HTTP answer crosses a rejected certificate: {body}"
+        );
     }
 
     #[derive(serde::Deserialize)]
@@ -3177,6 +3626,7 @@ non-ephemeral ports — a product regression, not a port race. Attempts: {failur
                     let (mark_read, _receiver) = std::sync::mpsc::channel();
                     handle_connection(
                         stream,
+                        test_tls_config(),
                         snapshot,
                         mark_read,
                         None,
@@ -3237,6 +3687,7 @@ non-ephemeral ports — a product regression, not a port race. Attempts: {failur
                 });
                 let server = MobileServer {
                     port,
+                    certificate_fingerprint: String::new(),
                     shutdown,
                     bonjour: Arc::new(Mutex::new(None)),
                     remote: Arc::new(Mutex::new(
@@ -3635,6 +4086,15 @@ non-ephemeral ports — a product regression, not a port race. Attempts: {failur
                         .expect("descriptor json")
                     )
                 );
+                // Both TLS signals the phone reads: the capability id, and
+                // the Host version as the fallback (`>= 0.5.3` means TLS).
+                assert!(
+                    response["hostProtocol"]["capabilities"]
+                        .as_array()
+                        .is_some_and(|ids| ids.iter().any(|id| id == "host.mobile.tls")),
+                    "bootstrap advertises host.mobile.tls"
+                );
+                assert_eq!(response["serverVersion"], env!("CARGO_PKG_VERSION"));
                 // Lane D additive fields: the isolation tier is always
                 // present and one of the three values; the environment is
                 // optional and, when present, a Box descriptor.

--- a/crates/unpeel-serve/src/pairing.rs
+++ b/crates/unpeel-serve/src/pairing.rs
@@ -424,6 +424,10 @@ impl PairingWindow {
         }
 
         let (remote_port, fingerprint) = crate::mobile::remote_server_advertisement();
+        // The direct `/mobile` listener serves the same Host certificate as
+        // the WSS streamer, so a freshly paired device always receives the
+        // pin — even while the streamer is down.
+        let fingerprint = fingerprint.or_else(crate::mobile::direct_certificate_fingerprint);
         let engine = base64::engine::general_purpose::STANDARD;
         let mut response = serde_json::json!({
             "protocolVersion": 1,
@@ -433,6 +437,9 @@ impl PairingWindow {
             "deviceID": device_id,
             "authToken": auth_token,
             "pairedAtUnixMs": now_ms(),
+            // Additive: the Host version, the phone's fallback TLS signal
+            // (`>= 0.5.3` serves the direct endpoint over TLS).
+            "serverVersion": env!("CARGO_PKG_VERSION"),
             // Required by the phone's decoder even on LAN-only pairings.
             "relayCredentials": {
                 "relayURL": relay_url(),
@@ -445,6 +452,9 @@ impl PairingWindow {
             response["directEndpoint"] = active.direct_endpoint.clone().into();
         }
         if let Some(obj) = response.as_object_mut() {
+            // Additive: the direct endpoint above is served over TLS with the
+            // certificate named by `remoteServerCertificateFingerprint`.
+            obj.insert("directTLS".into(), true.into());
             if let Some(port) = remote_port {
                 obj.insert("remoteServerPort".into(), port.into());
             }

--- a/docs/agents/serve.md
+++ b/docs/agents/serve.md
@@ -104,6 +104,50 @@ toggle per-device Link allowance. The app never constructs
 `RelayUplinkManager` in this path. `unpeel-attach` remains the direct terminal
 data plane and the worker supervises exactly one `__remote__` TLS streamer.
 
+### Direct `/mobile` transport: TLS with the Host certificate
+
+The direct `/mobile` listener (`crates/unpeel-serve/src/mobile.rs`) binds all
+interfaces on the persisted phone port and serves HTTP/1.1 **over TLS** with
+the Host certificate — the same self-signed material under
+`<home>/remote/tls/` that the `__remote__` WSS streamer serves
+(`unpeel_core::remote_server::ensure_tls_material`). A Controller therefore
+holds one fingerprint pin for both transports: the sealed pairing response and
+`/mobile/bootstrap` carry it as `remoteServerCertificateFingerprint`
+(advertised whenever the direct listener has it, streamer alive or not),
+`serve.json.directCertificateFingerprint` publishes it for operators, and the
+bootstrap capability `host.mobile.tls` (`protocol/host-capabilities-v1.json`,
+protocol 1.15) tells a Controller the endpoint is TLS. Bootstrap and the
+sealed pairing response also carry the additive `serverVersion` (the Host's
+crate version, e.g. `"0.5.3"`), the phone's fallback signal when the
+capability list is unavailable (`serverVersion >= 0.5.3` means TLS), and the
+pairing response adds `directTLS: true`. Without loadable certificate
+material there is no listener (fail closed); a cleartext-only server would
+refuse every paired device anyway.
+
+One port carries both transports during the client transition. Each accepted
+socket is classified by peeking its first byte (`0x16` is a TLS ClientHello;
+`Transport::Tls` / `Transport::Plaintext`), and the plaintext gate runs before
+routing and before any token lookup: a cleartext request that presents an
+`Authorization` header is answered `426 Upgrade Required`
+(`Upgrade: TLS/1.3, HTTP/1.1`, `Connection: close`, body
+`{"error":"use https"}`) and the token is never hashed or compared. Plaintext
+may still reach `POST /mobile/pair`, whose exchange is sealed at the
+application layer, so the QR-code pairing client and `unpeel pair` work
+unchanged; every other plaintext request gets the 401/404 it always got. The
+advertised endpoint string stays `http://<lan>:<port>/mobile` for the shipped
+Controllers' parsers; a TLS-aware Controller connects HTTPS to that authority
+with its pin. Phones on builds that still speak cleartext fall back to the
+relay path, which is unaffected.
+
+Proofs: `mobile.rs` unit tests (first-byte classification, the gate's truth
+table, plaintext bearer → 426 end to end, TLS bearer past the gate, pairing on
+both transports, a wrong pin never completing the handshake), the process
+tests `serve_command.rs`, `remote_streamer_supervision_process.rs`, and
+`local_gateway_process.rs` (pinned TLS clients via
+`unpeel_core::remote_attach::pinned_client_config`), and the PTY matrix, whose
+`mobile_request` helper pins the private home's certificate the way a phone
+does (`crates/unpeel-cli/tests/harness.py`).
+
 ### Terminal streamer supervision
 
 The worker owns the `unpeel-host __remote__` TLS/WSS streamer's whole

--- a/protocol/host-capabilities-v1.json
+++ b/protocol/host-capabilities-v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "protocol": {
     "major": 1,
-    "minor": 14,
+    "minor": 15,
     "compatibility": {
       "major": "must-match",
       "minor": "additive",
@@ -70,6 +70,13 @@
       "id": "host.bootstrap",
       "method": "GET",
       "path": "/mobile/bootstrap",
+      "native": true,
+      "tui": true
+    },
+    {
+      "id": "host.mobile.tls",
+      "method": "TLS",
+      "path": "/mobile",
       "native": true,
       "tui": true
     },


### PR DESCRIPTION
## Security finding

The direct `/mobile` listener binds all interfaces and served plain HTTP, so after pairing every request carried the paired device's long-lived bearer token in cleartext on the LAN. Pairing (sealed at the application layer) and the terminal WebSocket stream (pinned TLS via `__remote__`) were already protected; the authenticated HTTP surface was not.

## What changed

**TLS on the same port, with the Host's existing pinned certificate** (`crates/unpeel-serve/src/mobile.rs`)
- The listener now serves HTTP/1.1 over TLS using the certificate under `<home>/remote/tls/` — the same material the `__remote__` WSS streamer serves (`unpeel_core::remote_server::ensure_tls_material`), so a phone's existing fingerprint pin covers `/mobile` unchanged. No loadable certificate material → no listener (fail closed).
- **Transition dispatch by first byte**: each admitted socket is peeked (`MSG_PEEK`); `0x16` (TLS ClientHello) is wrapped in rustls, anything else is treated as cleartext HTTP. The peek and the TLS handshake run inside the admitted-connection path from #6, so the 5 s pre-auth deadline covers a stalled handshake too (the existing deadline test now stalls half its clients with a partial ClientHello).
- **Plaintext gate before any token lookup**: a cleartext request that presents an `Authorization` header is answered `426 Upgrade Required` (`Upgrade: TLS/1.3, HTTP/1.1`, `Connection: close`, body `{"error":"use https", ...}`) — the token is never hashed, compared, or authenticated, and the connection is never marked `authenticated` for the ledger. Plaintext may still reach `POST /mobile/pair` (sealed exchange), so the QR pairing client and `unpeel pair` work exactly as before; other unauthenticated plaintext requests keep their 401/404.

**Discovery — the contract the iOS lane built against** (no new channel)
- `protocol/host-capabilities-v1.json`: capability `host.mobile.tls` (`TLS /mobile`, native + tui); protocol minor 14 → 15; `controller_protocol.rs` constants updated (the ledger-alignment tests keep them in sync).
- Additive `serverVersion` (the Host crate version, `CARGO_PKG_VERSION`) on `/mobile/bootstrap` and in the sealed pairing response — the phone's fallback signal (`>= 0.5.3` means TLS) when the capability list is unavailable. Note: this branch still reports `0.5.2`; the release bump makes it `0.5.3`, and the capability wins whenever bootstrap is readable.
- `/mobile/bootstrap` now always carries `remoteServerCertificateFingerprint` when the direct listener has it (previously only while the streamer was alive); the sealed pairing response does the same and adds `directTLS: true`.
- `serve.json` gains `directCertificateFingerprint` (additive) for operators and tests.

**Core helpers** (`crates/unpeel-core`)
- `pub use rustls` re-export (native-host feature) so serve and tests share one TLS stack; `remote_server::{ensure_tls_material_in, build_tls_config}` and `remote_attach::pinned_client_config` made public. No new dependencies; `Cargo.lock` unchanged.

**Docs**: new section "Direct `/mobile` transport: TLS with the Host certificate" in `docs/agents/serve.md`; module doc in `mobile.rs`; `crates/unpeel-cli/tests/README.md`.

## Tests

- `mobile.rs` unit tests: first-byte classification; the gate's truth table (plaintext+credential → 426 on any route, TLS+bearer → passes, plaintext pairing → passes); end-to-end plaintext bearer → 426 with `Upgrade`/`Connection: close` (never 401 — the token is not looked up); TLS bearer past the gate with a pinned client; pairing route on both transports; a wrong pin never completes the handshake; the #6 deadline test now includes stalled TLS handshakes; the shared conformance fixture's `bootstrap.valid` asserts both TLS signals (`host.mobile.tls` and `serverVersion`).
- Process tests speak pinned TLS the way the phone does: `serve_command.rs` (TLS + paired bearer → 200 with `host.mobile.tls`, `serverVersion`, and the workspace certificate's fingerprint advertised; the same token in the clear → 426 `use https`), `remote_streamer_supervision_process.rs`, `local_gateway_process.rs`.
- PTY matrix: `harness.mobile_request` is HTTPS pinned to the private home's certificate (`host_certificate_pin`) — every case that talks to `/mobile` now proves TLS + bearer → 200; `plaintext_mobile_request` is the cleartext shape; `mobile.py` checks the capability, `serverVersion` (equals `serve.json.hostVersion`), the fingerprint in bootstrap and `serve.json`, and the 426.

## Gates

Run on the branch rebased onto `ce3c98b` (PR #6):

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo test --manifest-path crates/Cargo.toml -p unpeel-serve -p unpeel-core`: 811 + 137 passed, 0 failed (3 ignored, pre-existing).
- `cargo test -p unpeel-cli --test serve_command`: 1 passed. `cargo test -p unpeel-host --test local_gateway_process --test remote_streamer_supervision_process`: 7 + 2 passed.
- PTY matrix, the cases that talk to `/mobile`: `crates/unpeel-cli/tests/run.sh mobile standalone approvals pairing host_launch_conformance link_lifecycle state_bus compat_state relay_conformance` → 175 checks passed, 0 failed (the Swift-oracle halves of `pairing`/`relay_conformance` note-skipped as usual: no `swiftc`/Apple sources in this repo).

## Changelog note

- `unpeel serve`: the direct `/mobile` endpoint is served over TLS with the Host's pinned certificate; paired-device bearer tokens are refused (426 `use https`) over plaintext. Bootstrap advertises `host.mobile.tls` and `serverVersion` (protocol 1.15). QR-code pairing is unchanged.

## Compatibility

- The iOS client switches its `/mobile` requests to HTTPS with its existing pin (parallel lane, shipped against `host.mobile.tls` / `serverVersion >= 0.5.3` / 426). Phones on older builds get 426 on the LAN and fall back to the relay path, which is unaffected. The advertised endpoint string stays `http://<lan>:<port>/mobile`; the TLS-aware phone rewrites it to `https://` on the same port.
- Hosts ≤ 0.5.2 keep plaintext on the phone side by design; a new-build phone against such a Host sees neither signal and stays on plaintext.

## Deliberately left out

- `unpeel_core::direct_connection` (the Controller-side plaintext LAN transport library, unused inside this repo) still parses only `http://` endpoints; moving it to pinned TLS belongs with the Controller lane.
- A `503 too many connections` refusal (from #6) is still written in cleartext on the raw socket; a TLS client sees a failed handshake, which is the right outcome.
- The endpoint scheme in QR/pairing/`serve.json` was not changed to `https://` (see compatibility).
- The full PTY matrix was not run — only the cases that talk to `/mobile` (list under Gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
