### PR TITLE
pty-core: per-session write isolation, generation-checked reactor messages, children always reaped

### DIFF
--- a/crates/unpeel-cli/tests/cases/pty_core_isolation.py
+++ b/crates/unpeel-cli/tests/cases/pty_core_isolation.py
@@ -1,0 +1,339 @@
+"""Per-session isolation in the shared PTY core. One terminal that stops
+reading its input (a raw-mode child flooding device queries without
+consuming the answers, a raw-mode child that never reads at all) fills only
+its own bounded input queue: a sibling's control socket keeps answering
+within its normal timeout, its output keeps flowing, and the core's own
+ping stays honest. A `write` into the stuck terminal is refused promptly
+instead of parking the caller. Write ids are deduplicated at the reactor.
+Every ended Session's child is reaped, whether it ended through `kill` or
+(macOS) through the reactor observing the child's exit while a grandchild
+still holds the slave: no <defunct> child under the core, a real exit code
+in the manifest."""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from harness import (  # noqa: E402
+    CRATES,
+    run,
+    wait_running,
+)
+
+HOST_BIN = os.path.join(CRATES, "target", "debug", "unpeel-host")
+
+# The sibling's control socket must answer well inside the clients' own
+# timeouts (the CLI and serve use 2-5 s); the audit measured >700 ms stalls.
+SIBLING_PING_BUDGET = 0.7
+
+
+def request(path, body, timeout=5.0):
+    sock = socket.socket(socket.AF_UNIX)
+    sock.settimeout(timeout)
+    sock.connect(path)
+    sock.sendall((json.dumps(body) + "\n").encode())
+    chunks = b""
+    while not chunks.endswith(b"\n"):
+        piece = sock.recv(65536)
+        if not piece:
+            break
+        chunks += piece
+    sock.close()
+    return json.loads(chunks.decode() or "{}")
+
+
+def core_request(home, body, timeout=12.0):
+    return request(home.path("pty-core.sock"), body, timeout)
+
+
+def session_request(home, session_id, body, timeout=5.0):
+    return request(home.path("app-sessions", session_id, "session.sock"), body, timeout)
+
+
+def timed_ping(home, session_id, timeout=SIBLING_PING_BUDGET):
+    """(ok, seconds) for a ping on a Session's control socket."""
+    started = time.monotonic()
+    try:
+        reply = session_request(home, session_id, {"type": "ping"}, timeout)
+        return bool(reply.get("ok")), time.monotonic() - started
+    except (OSError, ValueError):
+        return False, time.monotonic() - started
+
+
+def core_record(home):
+    with open(home.path("pty-core.json")) as handle:
+        return json.load(handle)
+
+
+def start_core(home):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("UNPEEL_")}
+    env.update(UNPEEL_HOME=home.root, UNPEEL_TEST="1")
+    core = subprocess.Popen(
+        [HOST_BIN, "__pty_core__"],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    end = time.monotonic() + 15
+    while time.monotonic() < end:
+        try:
+            if core_record(home)["pid"] == core.pid:
+                return core
+        except (FileNotFoundError, ValueError, KeyError):
+            pass
+        if core.poll() is not None:
+            break
+        time.sleep(0.05)
+    return core
+
+
+class CoreStopper:
+    def __init__(self, core):
+        self.core = core
+
+    def close(self):
+        if self.core.poll() is None:
+            self.core.kill()
+            self.core.wait(timeout=10)
+
+
+def launch(case, home, session_id, command):
+    """Launch a Session in the core straight from a launch file (no
+    preset/CLI in between, so the command is exactly `command`)."""
+    launch_file = home.path(f"launch-{session_id}.json")
+    with open(launch_file, "w") as handle:
+        json.dump(
+            {
+                "session": {
+                    "id": session_id,
+                    "project_id": "p",
+                    "label": session_id,
+                    "command": command,
+                },
+                "cwd": home.root,
+                "mcp_enabled": False,
+            },
+            handle,
+        )
+    reply = core_request(home, {"op": "launch", "launch_file": launch_file}, timeout=30)
+    case.check(f"the core launches {session_id}", reply.get("ok"), str(reply))
+    case.check(f"{session_id} comes up running", wait_running(home, session_id), "never running")
+    wait_for(lambda: os.path.exists(home.path("app-sessions", session_id, "session.sock")))
+    return session_id
+
+
+def journal(home, session_id):
+    try:
+        with open(home.path("app-sessions", session_id, "output.bin"), "rb") as handle:
+            return handle.read()
+    except FileNotFoundError:
+        return b""
+
+
+def wait_for(predicate, timeout=15.0):
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if predicate():
+            return True
+        time.sleep(0.1)
+    return predicate()
+
+
+def process_state(pid):
+    """ps STAT for a pid: '' once it is gone, contains 'Z' while a zombie."""
+    return subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip()
+
+
+def check_reaped(case, home, session_id, child_pid, what):
+    manifest = home.manifests().get(session_id, {})
+    case.check(
+        f"{what}: the manifest is exited with a real exit code",
+        manifest.get("state") == "exited" and manifest.get("exit_code") is not None,
+        str({k: manifest.get(k) for k in ("state", "exit_code", "pid")}),
+    )
+    case.check(
+        f"{what}: the child {child_pid} is reaped (no zombie, not running)",
+        wait_for(lambda: process_state(child_pid) == "", timeout=10),
+        f"STAT={process_state(child_pid)!r}",
+    )
+
+
+def body(case):
+    home = case.home
+    home.project("p", "unpeel", home.root)
+
+    flood_program = home.path("flood.py")
+    with open(flood_program, "w") as handle:
+        handle.write(
+            "import os, sys, time, tty\n"
+            "tty.setraw(0)\n"
+            "os.write(1, b'READY')\n"
+            "while not os.path.exists(sys.argv[1]): time.sleep(0.02)\n"
+            # 30k DA1 queries; the Host answers each one and this child
+            # never reads a byte of the answers.
+            "os.write(1, b'\\x1b[c' * 30000)\n"
+            "os.write(1, b'FLOODED')\n"
+            "while True: time.sleep(1)\n"
+        )
+    trigger = home.path("flood-trigger")
+
+    core = start_core(home)
+    case.track(CoreStopper(core))
+    case.check("the core is up", core.poll() is None and core_record(home)["pid"] == core.pid)
+
+    ticker = launch(case, home, "ticker", "sh -c 'while :; do echo tick; sleep 0.05; done'")
+    flood = launch(case, home, "flood", f"python3 {flood_program} {trigger}")
+    stuck = launch(case, home, "stuck", "sh -c 'stty raw -echo; exec sleep 300'")
+    echo = launch(case, home, "echo", "cat")
+    case.check("the flood child is ready", wait_for(lambda: b"READY" in journal(home, flood)))
+    time.sleep(1.0)
+
+    # Baseline.
+    ok, seconds = timed_ping(home, ticker)
+    case.check("a healthy sibling answers ping promptly", ok and seconds < SIBLING_PING_BUDGET, f"{seconds:.3f}s")
+    before = len(journal(home, ticker))
+    time.sleep(0.5)
+    case.check("a healthy sibling produces output", len(journal(home, ticker)) > before)
+
+    # 1. A query flood whose answers are never consumed.
+    with open(trigger, "w"):
+        pass
+    case.check("the flood child emitted its queries", wait_for(lambda: b"FLOODED" in journal(home, flood), timeout=20))
+    time.sleep(0.5)
+    ok, seconds = timed_ping(home, ticker)
+    case.check(
+        "during the flood the sibling's control socket still answers within budget",
+        ok and seconds < SIBLING_PING_BUDGET,
+        f"ok={ok} {seconds:.3f}s",
+    )
+    before = len(journal(home, ticker))
+    time.sleep(1.0)
+    case.check("during the flood the sibling's output keeps flowing", len(journal(home, ticker)) > before)
+    ok, seconds = timed_ping(home, flood, timeout=2.0)
+    case.check("the flooding session's own control socket still answers", ok, f"{seconds:.3f}s")
+    case.check("the core's ping stays healthy", core_request(home, {"op": "ping"}).get("sessions") == 4)
+
+    # 2. A raw-mode child that never reads: writes into it are bounded and
+    #    refused promptly; nobody else notices.
+    started = time.monotonic()
+    accepted = refused = 0
+    refusal = ""
+    chunk = "x" * (64 * 1024)
+    for _ in range(40):
+        reply = session_request(home, stuck, {"type": "write", "data": chunk}, timeout=15)
+        if reply.get("ok"):
+            accepted += 1
+        else:
+            refused += 1
+            refusal = reply.get("error") or ""
+            break
+    elapsed = time.monotonic() - started
+    case.check(
+        "writes into a terminal that never reads are accepted up to the bound, then refused",
+        accepted >= 1 and refused == 1 and "not accepting input" in refusal,
+        f"accepted={accepted} refused={refused} error={refusal!r}",
+    )
+    case.check("the refusal comes promptly, not after a blocked write", elapsed < 10.0, f"{elapsed:.1f}s")
+    ok, seconds = timed_ping(home, ticker)
+    case.check(
+        "a stuck terminal's full queue never touches the sibling's control socket",
+        ok and seconds < SIBLING_PING_BUDGET,
+        f"ok={ok} {seconds:.3f}s",
+    )
+    ok, seconds = timed_ping(home, stuck, timeout=2.0)
+    case.check("the stuck session's own control socket still answers", ok, f"{seconds:.3f}s")
+    before = len(journal(home, ticker))
+    time.sleep(0.5)
+    case.check("the sibling's output still flows", len(journal(home, ticker)) > before)
+
+    # 3. Write ids are deduplicated at the reactor (echo + cat = 2 copies per delivery).
+    dedup = {"type": "write", "data": "dedup-once\n", "write_id": "isolation-dedup-1"}
+    first = session_request(home, echo, dedup)
+    retry = session_request(home, echo, dedup)
+    time.sleep(0.8)
+    case.check(
+        "a retried write id is applied once",
+        first.get("ok") and retry.get("ok") and journal(home, echo).count(b"dedup-once") == 2,
+        f"first={first} retry={retry} copies={journal(home, echo).count(b'dedup-once')}",
+    )
+    plain = session_request(home, echo, {"type": "write", "data": "plain\n"})
+    case.check("a write without an id still lands", plain.get("ok") and wait_for(lambda: journal(home, echo).count(b"plain") >= 2))
+
+    # 4. Ending Sessions whose children are alive: every child is reaped
+    #    and the manifest carries a real exit code.
+    children = {sid: home.manifests()[sid]["pid"] for sid in (flood, stuck, echo)}
+    for sid in (flood, stuck, echo):
+        reply = session_request(home, sid, {"type": "kill"}, timeout=15)
+        case.check(f"kill {sid} is acknowledged", reply.get("ok"), str(reply))
+    for sid in (flood, stuck, echo):
+        case.check(
+            f"{sid} reaches the exited state",
+            wait_for(lambda sid=sid: home.manifests().get(sid, {}).get("state") == "exited", timeout=20),
+            str(home.manifests().get(sid, {}).get("state")),
+        )
+        check_reaped(case, home, sid, children[sid], f"kill {sid}")
+    case.check("the core releases the ended sessions", wait_for(lambda: core_request(home, {"op": "ping"}).get("sessions") == 1, timeout=20))
+    ok, seconds = timed_ping(home, ticker)
+    case.check("the survivor still answers after its siblings ended", ok and seconds < SIBLING_PING_BUDGET, f"{seconds:.3f}s")
+
+    # 5. (macOS) The child exits while a grandchild keeps the slave open,
+    #    so the PTY never reaches EOF; the reactor's process watch ends the
+    #    Session and its teardown reaps the child.
+    if sys.platform == "darwin":
+        # The launch command runs inside the hosted login shell, which then
+        # execs the interactive fallback shell (same pid); the background
+        # job it leaves behind ignores HUP and keeps the slave open. `exit 3`
+        # typed into that shell ends the child without any PTY EOF.
+        bg = launch(case, home, "bg", 'trap "" HUP; sleep 120 & echo grandchild=$!')
+        case.check("the background job was started", wait_for(lambda: b"grandchild=" in journal(home, bg), timeout=20))
+        time.sleep(2.0)
+        bg_child = home.manifests()[bg]["pid"]
+        typed = session_request(home, bg, {"type": "write", "data": "exit 3\n"}, timeout=15)
+        case.check("exit is typed into the fallback shell", typed.get("ok"), str(typed))
+        case.check(
+            "a child that exits behind a live grandchild still ends its session",
+            wait_for(lambda: home.manifests().get(bg, {}).get("state") == "exited", timeout=15),
+            str(home.manifests().get(bg, {})),
+        )
+        manifest = home.manifests().get(bg, {})
+        case.check("that session records the child's real exit code", manifest.get("exit_code") == 3, str(manifest.get("exit_code")))
+        check_reaped(case, home, bg, bg_child, "child exit without EOF")
+        text = journal(home, bg).decode(errors="replace")
+        grandchild = 0
+        if "grandchild=" in text:
+            digits = ""
+            for ch in text.split("grandchild=", 1)[1]:
+                if not ch.isdigit():
+                    break
+                digits += ch
+            grandchild = int(digits or 0)
+        case.check("the grandchild was still alive (EOF is not what ended the session)", grandchild and process_state(grandchild) not in ("", "Z"), f"pid={grandchild} STAT={process_state(grandchild)!r}")
+        if grandchild:
+            try:
+                os.kill(grandchild, 9)
+            except ProcessLookupError:
+                pass
+
+    ticker_child = home.manifests()[ticker]["pid"]
+    session_request(home, ticker, {"type": "kill"}, timeout=15)
+    case.check("the last session exits", wait_for(lambda: home.manifests().get(ticker, {}).get("state") == "exited", timeout=20))
+    check_reaped(case, home, ticker, ticker_child, "kill ticker")
+    case.check("the core is empty", wait_for(lambda: core_request(home, {"op": "ping"}).get("sessions") == 0, timeout=20))
+    case.check("the core shuts down cleanly", core_request(home, {"op": "shutdown"}).get("ok"))
+    try:
+        core.wait(timeout=15)
+        exited = core.returncode == 0
+    except subprocess.TimeoutExpired:
+        exited = False
+    case.check("the core exited 0", exited, str(core.returncode))
+
+
+run("pty_core_isolation", body)

--- a/crates/unpeel-core/src/core_reactor.rs
+++ b/crates/unpeel-core/src/core_reactor.rs
@@ -10,6 +10,21 @@
 //! `wait` for events. Fairness comes from the loop shape — one bounded read
 //! per ready PTY per pass — not from edge-triggered draining.
 //!
+//! Two invariants keep one Session from touching another:
+//!
+//! - **The reactor thread never blocks on a Session.** Every PTY write it
+//!   performs is a non-blocking write into that Session's bounded input
+//!   queue (`SessionIo::drain_pending_input`); one-shot `Write` commands
+//!   submit into the same queue (`Control::Input`) instead of writing the
+//!   PTY themselves, so no transient thread ever holds a lock the reactor
+//!   needs across a blocking write. A wedged terminal fills its own queue
+//!   and is told so; its siblings' sockets keep answering.
+//! - **Slots are identities only together with a generation.** Every
+//!   cross-thread message about a Session carries a [`SlotRef`] (slot +
+//!   monotonic generation) and is dropped when the generation no longer
+//!   matches, and a freed slot is not reused until the teardown thread that
+//!   owns its last messages has reported done (`Control::SessionEnded`).
+//!
 //! Child module of `session_host`, like `session_io`.
 
 use super::session_io::{
@@ -155,6 +170,28 @@ mod sys {
             Ok(())
         }
 
+        /// Drop a process watch (a Session ended before its child did).
+        pub fn unwatch_process(&self, pid: u32) {
+            let change = libc::kevent {
+                ident: pid as libc::uintptr_t,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_DELETE,
+                fflags: 0,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+            let _ = unsafe {
+                libc::kevent(
+                    self.kq,
+                    &change,
+                    1,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null(),
+                )
+            };
+        }
+
         pub fn wait(&mut self, timeout: Option<Duration>) -> std::io::Result<Vec<PollEvent>> {
             let ts = timeout.map(|t| libc::timespec {
                 tv_sec: t.as_secs() as libc::time_t,
@@ -270,6 +307,8 @@ mod sys {
             ))
         }
 
+        pub fn unwatch_process(&self, _pid: u32) {}
+
         pub fn wait(&mut self, timeout: Option<Duration>) -> std::io::Result<Vec<PollEvent>> {
             let timeout_ms = timeout
                 .map(|t| t.as_millis().min(i32::MAX as u128) as libc::c_int)
@@ -329,7 +368,7 @@ pub(crate) struct Registry {
 }
 
 impl Registry {
-    fn new() -> std::io::Result<Self> {
+    pub(crate) fn new() -> std::io::Result<Self> {
         Ok(Self {
             poller: sys::Poller::new()?,
             next_token: 1,
@@ -372,8 +411,8 @@ impl Registry {
         self.owners.remove(&token);
     }
 
-    /// Watch a non-child process for exit; `Ok(None)` when the platform
-    /// has no such watch.
+    /// Watch a process for exit (a hosted child, owned or handed over);
+    /// `Ok(None)` when the platform has no such watch.
     pub(crate) fn watch_process(&mut self, pid: u32, slot: usize) -> Result<Option<u64>, String> {
         let token = self.next_token;
         self.next_token = self.next_token.wrapping_add(1).max(1);
@@ -386,6 +425,24 @@ impl Registry {
             Err(error) => Err(format!("Failed to watch process {pid}: {error}")),
         }
     }
+
+    /// Forget a process watch before its event fires (the Session ended
+    /// first); a late event for the token is then ignored by `owners`.
+    pub(crate) fn unwatch_process(&mut self, pid: u32, token: u64) {
+        self.poller.unwatch_process(pid);
+        self.owners.remove(&token);
+    }
+}
+
+/// The identity of a hosted Session inside the reactor: its slot plus the
+/// generation that occupied it. Every message from another thread names
+/// one of these, and the reactor drops any whose generation is not the
+/// slot's current one, so a late timer/journal/teardown message for a
+/// Session that already left can never reach the slot's next occupant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SlotRef {
+    pub slot: usize,
+    pub generation: u64,
 }
 
 // ───────────────────────────── waker ─────────────────────────────
@@ -453,13 +510,26 @@ pub(crate) enum Control {
     },
     /// Revisit a Session: `running` flipped, or a broadcaster write happened
     /// off the reactor thread.
-    Wake(usize),
+    Wake(SlotRef),
+    /// Bytes for a Session's PTY from a one-shot `Write` command. The
+    /// reactor checks `write_id` against the Session's ledger, queues the
+    /// bytes into its bounded input queue, records the id, and answers
+    /// `Ok(true)` (queued), `Ok(false)` (duplicate id, nothing queued), or
+    /// `Err` (queue full or Session gone). The submitting thread never
+    /// touches the PTY itself.
+    Input {
+        slot: SlotRef,
+        data: Vec<u8>,
+        write_id: Option<String>,
+        ack: mpsc::Sender<Result<bool, String>>,
+    },
     /// The journal writer drained this Session below the low mark.
-    JournalDrained(usize),
+    JournalDrained(SlotRef),
     /// The journal writer failed for this Session; end it.
-    JournalFailed(usize),
-    /// A teardown finished; release freed heap on the next idle tick.
-    SessionEnded,
+    JournalFailed(SlotRef),
+    /// A teardown finished: its slot may be reused now, and freed heap is
+    /// released on the next idle tick.
+    SessionEnded(SlotRef),
     /// Hand every hosted Session (and the core's own lock/listener fds) to
     /// the new core on the other end of `stream`; reply on `done`.
     Handoff {
@@ -498,15 +568,24 @@ pub(crate) enum JournalMsg {
 }
 
 pub(crate) enum TimerMsg {
+    /// Install a Session's jobs; replaces whatever an older generation left
+    /// in the slot.
     Add {
-        slot: usize,
+        slot: SlotRef,
         jobs: Vec<HostTimerJob>,
     },
+    /// Retire a Session's jobs. Always acked; a stale generation retires
+    /// nothing (the slot already belongs to a newer Session).
     Remove {
-        slot: usize,
+        slot: SlotRef,
         ack: mpsc::Sender<()>,
     },
 }
+
+/// How long a one-shot `Write` waits for the reactor to queue its bytes.
+/// The reactor never blocks on a Session, so this only trips while it is
+/// busy with a handoff; the bytes still land when it gets to them.
+const INPUT_SUBMIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub(crate) struct ReactorHandle {
@@ -515,8 +594,34 @@ pub(crate) struct ReactorHandle {
 }
 
 impl ReactorHandle {
-    pub(crate) fn session_ended(&self) {
-        self.send(Control::SessionEnded);
+    pub(crate) fn session_ended(&self, slot: SlotRef) {
+        self.send(Control::SessionEnded(slot));
+    }
+
+    /// Queue `data` for a Session's PTY from a transient command thread.
+    /// See `Control::Input` for the reply.
+    pub(crate) fn submit_input(
+        &self,
+        slot: SlotRef,
+        data: Vec<u8>,
+        write_id: Option<String>,
+    ) -> Result<bool, String> {
+        let (ack_tx, ack_rx) = mpsc::channel();
+        self.send(Control::Input {
+            slot,
+            data,
+            write_id,
+            ack: ack_tx,
+        });
+        match ack_rx.recv_timeout(INPUT_SUBMIT_TIMEOUT) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                Err("Write error: the session host did not accept input in time".into())
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err("Write error: session is no longer hosted".into())
+            }
+        }
     }
 
     /// Run a handoff of every hosted Session to the core on `stream`.
@@ -538,7 +643,7 @@ impl ReactorHandle {
             .unwrap_or_else(|_| Err("reactor dropped the handoff".into()))
     }
 
-    pub(crate) fn wake_session(&self, slot: usize) {
+    pub(crate) fn wake_session(&self, slot: SlotRef) {
         let _ = self.control_tx.send(Control::Wake(slot));
         self.waker.wake();
     }
@@ -609,16 +714,7 @@ fn start_services() -> Result<CoreServices, String> {
     thread::Builder::new()
         .name("core-reactor".into())
         .spawn(move || {
-            let mut reactor = Reactor {
-                registry,
-                waker,
-                control_rx,
-                timer_tx: timer_for_loop,
-                sessions: Vec::new(),
-                free_slots: Vec::new(),
-                release_pending: false,
-                process_watches: HashMap::new(),
-            };
+            let mut reactor = Reactor::new(registry, waker, control_rx, timer_for_loop);
             reactor.run();
         })
         .map_err(|e| format!("Failed to spawn reactor: {e}"))?;
@@ -644,58 +740,100 @@ pub(crate) fn host_session(session: SessionIo) -> Result<(), String> {
 
 // ───────────────────────────── reactor ─────────────────────────────
 
+/// A child-exit watch: which Session it belongs to and where its status
+/// goes (shared with a `HandedOverChild`, informational for an owned one).
+struct ProcessWatch {
+    slot: SlotRef,
+    pid: u32,
+    exit_slot: Arc<Mutex<Option<portable_pty::ExitStatus>>>,
+}
+
 struct Reactor {
     registry: Registry,
     waker: Arc<Waker>,
     control_rx: mpsc::Receiver<Control>,
     timer_tx: mpsc::Sender<TimerMsg>,
     sessions: Vec<Option<Box<SessionIo>>>,
+    /// The generation currently (or last) occupying each slot; bumped on
+    /// every registration so a `SlotRef` from an earlier occupant fails
+    /// the check in `with_session_ref`.
+    generations: Vec<u64>,
+    /// Slots whose last occupant's teardown has reported done. A slot
+    /// leaves `sessions` at `end_session` but only arrives here on
+    /// `Control::SessionEnded`, so no late message from that teardown can
+    /// meet a new occupant.
     free_slots: Vec<usize>,
     /// Set by a finished teardown; the idle tick runs the allocator release
     /// once, after every racing teardown has had its say.
     release_pending: bool,
-    /// Exit slots of handed-over children being watched, by process token.
-    process_watches: HashMap<u64, Arc<Mutex<Option<portable_pty::ExitStatus>>>>,
+    /// Child-exit watches by process token.
+    process_watches: HashMap<u64, ProcessWatch>,
 }
 
 impl Reactor {
+    fn new(
+        registry: Registry,
+        waker: Arc<Waker>,
+        control_rx: mpsc::Receiver<Control>,
+        timer_tx: mpsc::Sender<TimerMsg>,
+    ) -> Self {
+        Self {
+            registry,
+            waker,
+            control_rx,
+            timer_tx,
+            sessions: Vec::new(),
+            generations: Vec::new(),
+            free_slots: Vec::new(),
+            release_pending: false,
+            process_watches: HashMap::new(),
+        }
+    }
+
     fn run(&mut self) {
         let mut last_tick = Instant::now();
         loop {
-            self.drain_control();
-            let events = match self.registry.poller.wait(Some(REACTOR_IDLE_TICK)) {
-                Ok(events) => events,
-                Err(error) => {
-                    log::error!("reactor wait failed: {error}");
-                    thread::sleep(Duration::from_millis(50));
-                    continue;
-                }
+            self.run_once(REACTOR_IDLE_TICK, &mut last_tick);
+        }
+    }
+
+    /// One pass: control messages, one poll, one bounded read per ready
+    /// PTY, one batched frame per touched client, and the idle tick when
+    /// it is due.
+    fn run_once(&mut self, wait: Duration, last_tick: &mut Instant) {
+        self.drain_control();
+        let events = match self.registry.poller.wait(Some(wait)) {
+            Ok(events) => events,
+            Err(error) => {
+                log::error!("reactor wait failed: {error}");
+                thread::sleep(Duration::from_millis(50));
+                return;
+            }
+        };
+        let mut touched: Vec<usize> = Vec::new();
+        for event in events {
+            if event.token == WAKER_TOKEN {
+                self.waker.drain();
+                continue;
+            }
+            let Some(&(slot, kind)) = self.registry.owners.get(&event.token) else {
+                continue;
             };
-            let mut touched: Vec<usize> = Vec::new();
-            for event in events {
-                if event.token == WAKER_TOKEN {
-                    self.waker.drain();
-                    continue;
-                }
-                let Some(&(slot, kind)) = self.registry.owners.get(&event.token) else {
-                    continue;
-                };
-                self.dispatch(slot, kind, event, &mut touched);
-            }
-            // Push freshly broadcast output to streaming clients in the same
-            // pass it was read: one batched frame per pass per client.
-            touched.sort_unstable();
-            touched.dedup();
-            for slot in touched {
-                self.with_session(slot, |session, registry| {
-                    session.flush_stream_clients(registry);
-                    None
-                });
-            }
-            if last_tick.elapsed() >= REACTOR_IDLE_TICK {
-                last_tick = Instant::now();
-                self.idle_tick();
-            }
+            self.dispatch(slot, kind, event, &mut touched);
+        }
+        // Push freshly broadcast output to streaming clients in the same
+        // pass it was read: one batched frame per pass per client.
+        touched.sort_unstable();
+        touched.dedup();
+        for slot in touched {
+            self.with_session(slot, |session, registry| {
+                session.flush_stream_clients(registry);
+                None
+            });
+        }
+        if last_tick.elapsed() >= REACTOR_IDLE_TICK {
+            *last_tick = Instant::now();
+            self.idle_tick();
         }
     }
 
@@ -708,13 +846,28 @@ impl Reactor {
     ) {
         match kind {
             TokenKind::Process => {
-                if let Some(exit_slot) = self.process_watches.remove(&event.token) {
-                    super::session_io::record_child_exit(&exit_slot, event.process_exit);
-                }
                 self.registry.owners.remove(&event.token);
-                // The shell is gone; its PTY reaches EOF on its own, and a
-                // retained slave is caught by the stop path like a Kill.
+                let Some(watch) = self.process_watches.remove(&event.token) else {
+                    return;
+                };
+                super::session_io::record_child_exit(&watch.exit_slot, event.process_exit);
+                // The child is gone. Its PTY usually reaches EOF on its own,
+                // but not when a grandchild still holds the slave: end the
+                // Session the way a Kill does (drain what is buffered, then
+                // stop) so the teardown reaps the child instead of leaving
+                // a zombie under the core for as long as the slave lives.
                 let _ = slot;
+                let ended = self.with_session_ref(watch.slot, |session, registry| {
+                    session.clear_child_watch();
+                    session.shared.running.store(false, Ordering::Relaxed);
+                    match session.drain_after_stop(registry) {
+                        ReadOutcome::Ended => Some(Ok(())),
+                        ReadOutcome::Continue => None,
+                    }
+                });
+                if let Some(outcome) = ended {
+                    self.end_session(watch.slot.slot, outcome);
+                }
             }
             TokenKind::Pty => {
                 if event.writable {
@@ -791,45 +944,81 @@ impl Reactor {
         }
     }
 
+    /// `with_session` for a message from another thread: runs only when the
+    /// slot is still occupied by the generation the message names.
+    fn with_session_ref(
+        &mut self,
+        slot: SlotRef,
+        f: impl FnOnce(&mut SessionIo, &mut Registry) -> Option<Result<(), String>>,
+    ) -> Option<Result<(), String>> {
+        if !self.slot_is_current(slot) {
+            return None;
+        }
+        self.with_session(slot.slot, f)
+    }
+
+    fn slot_is_current(&self, slot: SlotRef) -> bool {
+        self.generations.get(slot.slot) == Some(&slot.generation)
+            && self.sessions.get(slot.slot).is_some_and(|s| s.is_some())
+    }
+
     fn drain_control(&mut self) {
         while let Ok(control) = self.control_rx.try_recv() {
             match control {
                 Control::Register { session, ack } => {
-                    let result = self.register(*session);
+                    let result = self.register(*session).map(|_| ());
                     let _ = ack.send(result);
                 }
                 Control::Wake(slot) => {
                     let mut needs_flush = false;
-                    let ended = self.with_session(slot, |session, registry| {
+                    let ended = self.with_session_ref(slot, |session, registry| {
                         needs_flush = true;
                         if !session.shared.running.load(Ordering::Relaxed) {
                             match session.drain_after_stop(registry) {
                                 ReadOutcome::Ended => return Some(Ok(())),
                                 ReadOutcome::Continue => {}
                             }
+                        } else if let Err(error) = session.drain_pending_input(registry) {
+                            log::warn!("{}: {error}", session.session_id());
                         }
                         None
                     });
                     if let Some(outcome) = ended {
-                        self.end_session(slot, outcome);
+                        self.end_session(slot.slot, outcome);
                     } else if needs_flush {
-                        self.with_session(slot, |session, registry| {
+                        self.with_session_ref(slot, |session, registry| {
                             session.flush_stream_clients(registry);
                             None
                         });
                     }
                 }
+                Control::Input {
+                    slot,
+                    data,
+                    write_id,
+                    ack,
+                } => {
+                    let mut result = Err("Write error: session is no longer hosted".to_string());
+                    self.with_session_ref(slot, |session, registry| {
+                        result = session.submit_input(registry, data, write_id.as_deref());
+                        None
+                    });
+                    let _ = ack.send(result);
+                }
                 Control::JournalDrained(slot) => {
-                    self.with_session(slot, |session, registry| {
+                    self.with_session_ref(slot, |session, registry| {
                         session.journal_drained(registry);
                         None
                     });
                 }
                 Control::JournalFailed(slot) => {
-                    self.end_session(slot, Err("Failed to write output log".into()));
+                    if self.slot_is_current(slot) {
+                        self.end_session(slot.slot, Err("Failed to write output log".into()));
+                    }
                 }
-                Control::SessionEnded => {
+                Control::SessionEnded(slot) => {
                     self.release_pending = true;
+                    self.release_slot(slot);
                 }
                 Control::Handoff {
                     stream,
@@ -852,22 +1041,64 @@ impl Reactor {
         }
     }
 
-    fn register(&mut self, mut session: SessionIo) -> Result<(), String> {
+    /// A teardown reported done: the slot it used may host again. Only the
+    /// generation that owned the teardown frees it; a stale report (or one
+    /// for a slot that already has a new occupant) frees nothing.
+    fn release_slot(&mut self, slot: SlotRef) {
+        if self.generations.get(slot.slot) != Some(&slot.generation) {
+            return;
+        }
+        if self.sessions.get(slot.slot).is_some_and(|s| s.is_some()) {
+            return;
+        }
+        if !self.free_slots.contains(&slot.slot) {
+            self.free_slots.push(slot.slot);
+        }
+    }
+
+    /// Host a Session. Returns its identity once its fds are registered,
+    /// its timer jobs installed, and (where the platform can) its child
+    /// watched for exit.
+    fn register(&mut self, mut session: SessionIo) -> Result<SlotRef, String> {
         let slot = match self.free_slots.pop() {
             Some(slot) => slot,
             None => {
                 self.sessions.push(None);
+                self.generations.push(0);
                 self.sessions.len() - 1
             }
         };
+        let generation = self.generations[slot] + 1;
+        self.generations[slot] = generation;
+        let slot_ref = SlotRef { slot, generation };
         let jobs = session.take_timer_jobs();
-        if let Err(error) = session.register(&mut self.registry, slot) {
+        if let Err(error) = session.register(&mut self.registry, slot_ref) {
             self.free_slots.push(slot);
             return Err(error);
         }
-        let _ = self.timer_tx.send(TimerMsg::Add { slot, jobs });
+        let _ = self.timer_tx.send(TimerMsg::Add {
+            slot: slot_ref,
+            jobs,
+        });
+        if let Some((pid, exit_slot)) = session.child_watch() {
+            match self.registry.watch_process(pid, slot) {
+                Ok(Some(token)) => {
+                    session.set_child_watch_token(token);
+                    self.process_watches.insert(
+                        token,
+                        ProcessWatch {
+                            slot: slot_ref,
+                            pid,
+                            exit_slot,
+                        },
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => log::warn!("{}: {error}", session.session_id()),
+            }
+        }
         self.sessions[slot] = Some(Box::new(session));
-        Ok(())
+        Ok(slot_ref)
     }
 
     fn end_session(&mut self, slot: usize, outcome: Result<(), String>) {
@@ -877,7 +1108,15 @@ impl Reactor {
         let Some(session) = slot_ref.take() else {
             return;
         };
-        self.free_slots.push(slot);
+        let identity = SlotRef {
+            slot,
+            generation: self.generations[slot],
+        };
+        if let Some(token) = session.child_watch_token() {
+            if let Some(watch) = self.process_watches.remove(&token) {
+                self.registry.unwatch_process(watch.pid, token);
+            }
+        }
         let registry = &mut self.registry;
         let teardown: Option<SessionTeardown> =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| session.finish(registry)))
@@ -886,38 +1125,35 @@ impl Reactor {
             crate::hook_assets::append_trace_log_line(&format!(
                 "pty-core session slot {slot} panicked while finishing"
             ));
+            // No teardown thread will report for this slot.
+            self.free_slots.push(slot);
             return;
         };
         let timer_tx = self.timer_tx.clone();
-        // The epilogue waits on the writer and timer acks and takes the
-        // manifest lock; keep that off the reactor so no other Session
-        // notices a neighbour leaving.
+        // The epilogue waits on the writer and timer acks, reaps the child,
+        // and takes the manifest lock; keep that off the reactor so no
+        // other Session notices a neighbour leaving. The slot stays out of
+        // `free_slots` until that thread reports `SessionEnded`.
         if thread::Builder::new()
             .name("session-exit".into())
             .spawn(move || teardown.run(&timer_tx, outcome))
             .is_err()
         {
             log::error!("failed to spawn session teardown thread");
+            self.free_slots.push(identity.slot);
         }
     }
 
     fn adopt(
         &mut self,
-        session: SessionIo,
+        mut session: SessionIo,
         child_pid: Option<u32>,
         exit_slot: Arc<Mutex<Option<portable_pty::ExitStatus>>>,
     ) -> Result<(), String> {
-        let slot = match self.free_slots.last() {
-            Some(slot) => *slot,
-            None => self.sessions.len(),
-        };
-        self.register(session)?;
         if let Some(pid) = child_pid {
-            if let Ok(Some(token)) = self.registry.watch_process(pid, slot) {
-                self.process_watches.insert(token, exit_slot);
-            }
+            session.set_child_watch(pid, exit_slot);
         }
-        Ok(())
+        self.register(session).map(|_| ())
     }
 
     /// Move every hosted Session to the new core on `stream`. Runs on the
@@ -969,7 +1205,7 @@ impl Reactor {
             }
             let (timer_ack_tx, timer_ack_rx) = mpsc::channel();
             let _ = self.timer_tx.send(TimerMsg::Remove {
-                slot,
+                slot: session.slot_ref(),
                 ack: timer_ack_tx,
             });
             if timer_ack_rx.recv_timeout(Duration::from_secs(10)).is_err() {
@@ -1056,7 +1292,14 @@ impl Reactor {
             for (slot, export) in exports {
                 moved.push(export.meta.id);
                 if let Some(session) = self.sessions[slot].take() {
+                    // Forgetting is synchronous (no teardown thread will
+                    // report), so the slot is free right away.
                     self.free_slots.push(slot);
+                    if let Some(token) = session.child_watch_token() {
+                        if let Some(watch) = self.process_watches.remove(&token) {
+                            self.registry.unwatch_process(watch.pid, token);
+                        }
+                    }
                     session.forget_after_handoff(&mut self.registry);
                 }
             }
@@ -1072,7 +1315,10 @@ impl Reactor {
             let registry = &mut self.registry;
             if let Some(session) = self.sessions[slot].as_mut() {
                 let jobs = session.resume_after_handoff(registry);
-                let _ = self.timer_tx.send(TimerMsg::Add { slot, jobs });
+                let _ = self.timer_tx.send(TimerMsg::Add {
+                    slot: session.slot_ref(),
+                    jobs,
+                });
             }
         }
         Err(error)
@@ -1095,6 +1341,10 @@ impl Reactor {
                     if let ReadOutcome::Ended = session.drain_after_stop(registry) {
                         return Some(Ok(()));
                     }
+                } else if let Err(error) = session.drain_pending_input(registry) {
+                    // Input deferred behind an agent restart (see
+                    // `drain_pending_input`) is retried here at the latest.
+                    log::warn!("{}: {error}", session.session_id());
                 }
                 None
             });
@@ -1201,7 +1451,7 @@ fn run_journal_writer(rx: mpsc::Receiver<JournalMsg>, reactor: ReactorHandle) {
                 let Some(session) = sessions.get_mut(&id) else {
                     continue;
                 };
-                let slot = session.pressure.slot.load(Ordering::Acquire);
+                let slot = session.pressure.slot_ref();
                 let previous = session
                     .pressure
                     .backlog
@@ -1266,7 +1516,7 @@ fn run_journal_writer(rx: mpsc::Receiver<JournalMsg>, reactor: ReactorHandle) {
             {
                 session.flush();
                 if session.error.is_some() {
-                    failed.push(session.pressure.slot.load(Ordering::Acquire));
+                    failed.push(session.pressure.slot_ref());
                 }
             }
             session.release_idle_capacity(now);
@@ -1285,12 +1535,15 @@ fn run_journal_writer(rx: mpsc::Receiver<JournalMsg>, reactor: ReactorHandle) {
 /// never interleave with each other), and the idle tick never exceeds
 /// `HOST_TIMER_MAX_SLEEP` so a removal ack is never held hostage.
 fn run_timer(rx: mpsc::Receiver<TimerMsg>) {
-    let mut jobs: HashMap<usize, Vec<HostTimerJob>> = HashMap::new();
+    // Keyed by slot, tagged with the generation that installed the jobs:
+    // a `Remove` from an older generation (a teardown that lost the race
+    // with the slot's next occupant) retires nothing and is still acked.
+    let mut jobs: HashMap<usize, (u64, Vec<HostTimerJob>)> = HashMap::new();
     let running = AtomicBool::new(true);
     loop {
         let now = Instant::now();
         let mut next_wake = now + HOST_TIMER_MAX_SLEEP;
-        for (_, session_jobs) in jobs.iter_mut() {
+        for (_, (_, session_jobs)) in jobs.iter_mut() {
             session_jobs.retain_mut(|job| {
                 if now >= job.next_at {
                     let keep =
@@ -1317,10 +1570,23 @@ fn run_timer(rx: mpsc::Receiver<TimerMsg>) {
         while let Some(message) = pending.take() {
             match message {
                 TimerMsg::Add { slot, jobs: new } => {
-                    jobs.entry(slot).or_default().extend(new);
+                    let entry = jobs
+                        .entry(slot.slot)
+                        .or_insert((slot.generation, Vec::new()));
+                    if entry.0 != slot.generation {
+                        // A newer occupant: whatever the previous one left
+                        // is retired here, whether or not its Remove came.
+                        *entry = (slot.generation, Vec::new());
+                    }
+                    entry.1.extend(new);
                 }
                 TimerMsg::Remove { slot, ack } => {
-                    jobs.remove(&slot);
+                    if jobs
+                        .get(&slot.slot)
+                        .is_some_and(|(generation, _)| *generation == slot.generation)
+                    {
+                        jobs.remove(&slot.slot);
+                    }
                     let _ = ack.send(());
                 }
             }
@@ -1403,5 +1669,545 @@ mod tests {
         assert_eq!(std::fs::metadata(&path).unwrap().len(), 96 * 1024 + 4);
         let _ = reactor_handle_stub();
         let _ = UnixStream::pair();
+    }
+
+    // ───────────── isolation, slot identity, reaping (real PTYs) ─────────────
+
+    use super::super::session_io::test_support::{
+        child_is_reaped, pty_is_raw, short_dir, spawn_session, wait_until, TestSession,
+    };
+    use super::super::session_io::{reap_hosted_child, PENDING_PTY_INPUT_MAX_BYTES};
+    use super::super::{process_start_time_ms, recorded_pid_identity, HostTimerJob, PidIdentity};
+    use std::sync::atomic::AtomicUsize;
+
+    /// The three core threads as `start_services` wires them, with the
+    /// reactor itself kept on the test thread and driven by hand.
+    struct TestCore {
+        reactor: Reactor,
+        handle: ReactorHandle,
+        journal_tx: mpsc::Sender<JournalMsg>,
+        timer_tx: mpsc::Sender<TimerMsg>,
+    }
+
+    fn test_core() -> TestCore {
+        let (journal_tx, journal_rx) = mpsc::channel::<JournalMsg>();
+        let (timer_tx, timer_rx) = mpsc::channel::<TimerMsg>();
+        let (control_tx, control_rx) = mpsc::channel::<Control>();
+        let waker = Arc::new(Waker::new().unwrap());
+        let handle = ReactorHandle {
+            control_tx,
+            waker: Arc::clone(&waker),
+        };
+        let registry = Registry::new().unwrap();
+        registry
+            .poller
+            .set(waker.read_fd, WAKER_TOKEN, true, false)
+            .unwrap();
+        let writer_handle = handle.clone();
+        thread::spawn(move || run_journal_writer(journal_rx, writer_handle));
+        thread::spawn(move || run_timer(timer_rx));
+        let reactor = Reactor::new(registry, waker, control_rx, timer_tx.clone());
+        TestCore {
+            reactor,
+            handle,
+            journal_tx,
+            timer_tx,
+        }
+    }
+
+    fn ticking_job(ticks: &Arc<AtomicUsize>) -> HostTimerJob {
+        let ticks = Arc::clone(ticks);
+        HostTimerJob::new(Duration::ZERO, Duration::from_millis(5), move || {
+            ticks.fetch_add(1, Ordering::Relaxed);
+            true
+        })
+    }
+
+    fn ticks_advance(ticks: &Arc<AtomicUsize>) -> bool {
+        let before = ticks.load(Ordering::Relaxed);
+        thread::sleep(Duration::from_millis(80));
+        ticks.load(Ordering::Relaxed) > before
+    }
+
+    /// Process control messages until `done`, or fail after `timeout`.
+    fn pump(
+        reactor: &mut Reactor,
+        what: &str,
+        timeout: Duration,
+        mut done: impl FnMut(&Reactor) -> bool,
+    ) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            reactor.drain_control();
+            if done(reactor) {
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for {what}");
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn spawn_sleeper(
+        core: &TestCore,
+        dir: &std::path::Path,
+        id: &str,
+        ticks: &Arc<AtomicUsize>,
+    ) -> TestSession {
+        spawn_session(
+            dir,
+            id,
+            &["/bin/sleep", "300"],
+            core.handle.clone(),
+            core.journal_tx.clone(),
+            vec![ticking_job(ticks)],
+        )
+    }
+
+    #[test]
+    fn timer_retires_only_the_generation_that_installed_the_jobs() {
+        let (timer_tx, timer_rx) = mpsc::channel::<TimerMsg>();
+        thread::spawn(move || run_timer(timer_rx));
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let previous = SlotRef {
+            slot: 0,
+            generation: 1,
+        };
+        let current = SlotRef {
+            slot: 0,
+            generation: 2,
+        };
+        timer_tx
+            .send(TimerMsg::Add {
+                slot: current,
+                jobs: vec![ticking_job(&ticks)],
+            })
+            .unwrap();
+        wait_until("the job to run", Duration::from_secs(2), || {
+            ticks.load(Ordering::Relaxed) > 0
+        });
+
+        // A late Remove from the slot's previous occupant is acked (its
+        // teardown must not wait) and retires nothing.
+        let (ack_tx, ack_rx) = mpsc::channel();
+        timer_tx
+            .send(TimerMsg::Remove {
+                slot: previous,
+                ack: ack_tx,
+            })
+            .unwrap();
+        ack_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("a stale Remove is acked");
+        assert!(
+            ticks_advance(&ticks),
+            "the current occupant's jobs survive the previous occupant's Remove"
+        );
+
+        // The occupant's own Remove retires them.
+        let (ack_tx, ack_rx) = mpsc::channel();
+        timer_tx
+            .send(TimerMsg::Remove {
+                slot: current,
+                ack: ack_tx,
+            })
+            .unwrap();
+        ack_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(!ticks_advance(&ticks), "retired jobs stop running");
+
+        // An Add for a newer generation replaces whatever an older one left
+        // in the slot, whether or not its Remove ever came.
+        timer_tx
+            .send(TimerMsg::Add {
+                slot: current,
+                jobs: vec![ticking_job(&ticks)],
+            })
+            .unwrap();
+        wait_until("generation 2 to run again", Duration::from_secs(2), || {
+            ticks_advance(&ticks)
+        });
+        let newer = SlotRef {
+            slot: 0,
+            generation: 3,
+        };
+        let other = Arc::new(AtomicUsize::new(0));
+        timer_tx
+            .send(TimerMsg::Add {
+                slot: newer,
+                jobs: vec![ticking_job(&other)],
+            })
+            .unwrap();
+        wait_until("generation 3 to run", Duration::from_secs(2), || {
+            other.load(Ordering::Relaxed) > 0
+        });
+        assert!(
+            !ticks_advance(&ticks),
+            "generation 2's jobs were replaced by generation 3's"
+        );
+    }
+
+    /// Register N, end them, watch that their slots are not handed out
+    /// until each teardown reports done, register N more into exactly
+    /// those slots, then replay every late message the old occupants'
+    /// threads could still send: the new occupants keep their jobs and
+    /// stay hosted, and the old children were reaped.
+    #[test]
+    fn freed_slot_waits_for_the_teardown_and_stale_messages_never_reach_the_next_occupant() {
+        let dir = short_dir("slots");
+        let mut core = test_core();
+        const N: usize = 3;
+
+        let old_ticks = Arc::new(AtomicUsize::new(0));
+        let mut old: Vec<(SlotRef, TestSession)> = Vec::new();
+        for index in 0..N {
+            let mut session = spawn_sleeper(&core, &dir, &format!("old{index}"), &old_ticks);
+            let slot = core.reactor.register(session.session_take()).unwrap();
+            assert_eq!(
+                slot,
+                SlotRef {
+                    slot: index,
+                    generation: 1
+                }
+            );
+            old.push((slot, session));
+        }
+        wait_until(
+            "the old occupants' jobs to run",
+            Duration::from_secs(2),
+            || old_ticks.load(Ordering::Relaxed) > 0,
+        );
+
+        for (slot, _) in &old {
+            core.reactor.end_session(slot.slot, Ok(()));
+        }
+        assert!(
+            core.reactor.free_slots.is_empty(),
+            "a slot is not free while its teardown thread may still send for it"
+        );
+        // A Session registered meanwhile gets a slot of its own, never a
+        // retiring one.
+        let meanwhile_ticks = Arc::new(AtomicUsize::new(0));
+        let mut meanwhile = spawn_sleeper(&core, &dir, "meanwhile", &meanwhile_ticks);
+        let meanwhile_slot = core.reactor.register(meanwhile.session_take()).unwrap();
+        assert_eq!(
+            meanwhile_slot,
+            SlotRef {
+                slot: N,
+                generation: 1
+            }
+        );
+
+        for (_, session) in &old {
+            assert_eq!(
+                session
+                    .exited
+                    .recv_timeout(Duration::from_secs(20))
+                    .unwrap(),
+                Ok(())
+            );
+        }
+        pump(
+            &mut core.reactor,
+            "the teardowns to report",
+            Duration::from_secs(10),
+            |r| r.free_slots.len() == N,
+        );
+        for (_, session) in &old {
+            assert!(
+                child_is_reaped(session.child_pid),
+                "the old occupant's child {} was reaped by its teardown",
+                session.child_pid
+            );
+        }
+        assert!(
+            !ticks_advance(&old_ticks),
+            "the old occupants' jobs are retired"
+        );
+
+        let new_ticks = Arc::new(AtomicUsize::new(0));
+        let mut new: Vec<(SlotRef, TestSession)> = Vec::new();
+        for index in 0..N {
+            let mut session = spawn_sleeper(&core, &dir, &format!("new{index}"), &new_ticks);
+            let slot = core.reactor.register(session.session_take()).unwrap();
+            assert!(slot.slot < N, "the freed slots are reused: {slot:?}");
+            assert_eq!(slot.generation, 2);
+            new.push((slot, session));
+        }
+        wait_until(
+            "the new occupants' jobs to run",
+            Duration::from_secs(2),
+            || new_ticks.load(Ordering::Relaxed) > 0,
+        );
+
+        // Everything an old occupant's threads could still say, late.
+        for (slot, _) in &old {
+            let stale = *slot;
+            core.handle.send(Control::JournalFailed(stale));
+            core.handle.send(Control::JournalDrained(stale));
+            core.handle.send(Control::Wake(stale));
+            core.handle.send(Control::SessionEnded(stale));
+            let (ack_tx, ack_rx) = mpsc::channel();
+            core.timer_tx
+                .send(TimerMsg::Remove {
+                    slot: stale,
+                    ack: ack_tx,
+                })
+                .unwrap();
+            ack_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        }
+        core.reactor.drain_control();
+
+        for (slot, session) in &new {
+            assert!(
+                core.reactor.sessions[slot.slot].is_some(),
+                "{slot:?} is still hosted after the previous occupant's late messages"
+            );
+            assert_eq!(core.reactor.generations[slot.slot], 2);
+            assert_eq!(
+                recorded_pid_identity(session.child_pid, session.child_started_at),
+                PidIdentity::Matches,
+                "the new occupant's child is alive"
+            );
+        }
+        assert!(
+            !core.reactor.free_slots.iter().any(|s| *s < N),
+            "a stale SessionEnded frees nothing"
+        );
+        assert!(
+            ticks_advance(&new_ticks),
+            "the new occupants' timer jobs survive a stale Remove"
+        );
+
+        // Cleanup: end everything and wait for the reaps.
+        for (slot, _) in &new {
+            core.reactor.end_session(slot.slot, Ok(()));
+        }
+        core.reactor.end_session(meanwhile_slot.slot, Ok(()));
+        for session in new
+            .iter()
+            .map(|(_, s)| s)
+            .chain(std::iter::once(&meanwhile))
+        {
+            session
+                .exited
+                .recv_timeout(Duration::from_secs(20))
+                .unwrap()
+                .unwrap();
+            wait_until("the child to be reaped", Duration::from_secs(10), || {
+                child_is_reaped(session.child_pid)
+            });
+        }
+        pump(
+            &mut core.reactor,
+            "every teardown to report",
+            Duration::from_secs(10),
+            |r| r.free_slots.len() == N + 1,
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reap_hosted_child_terminates_and_waits_on_a_live_child() {
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+        let spawn = |command: &[&str]| {
+            let pair = native_pty_system()
+                .openpty(PtySize {
+                    rows: 24,
+                    cols: 80,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .unwrap();
+            let mut cmd = CommandBuilder::new(command[0]);
+            cmd.args(&command[1..]);
+            let child = pair.slave.spawn_command(cmd).unwrap();
+            drop(pair.slave);
+            (pair.master, child)
+        };
+
+        // Alive: asked to leave, waited on, gone from the process table.
+        let (_master, mut child) = spawn(&["/bin/sleep", "300"]);
+        let pid = child.process_id().unwrap();
+        let started = process_start_time_ms(pid);
+        let began = Instant::now();
+        let status = reap_hosted_child(child.as_mut(), started).expect("a status");
+        assert!(!status.success(), "a signalled child is not a success");
+        assert!(began.elapsed() < Duration::from_secs(3));
+        assert!(child_is_reaped(pid));
+        assert_eq!(
+            recorded_pid_identity(pid, started),
+            PidIdentity::NotOurs,
+            "the pid is gone"
+        );
+
+        // Already exited: waited on right away with its real code.
+        let (_master, mut child) = spawn(&["/bin/sh", "-c", "exit 7"]);
+        let pid = child.process_id().unwrap();
+        let started = process_start_time_ms(pid);
+        thread::sleep(Duration::from_millis(500));
+        let status = reap_hosted_child(child.as_mut(), started).expect("a status");
+        assert_eq!(status.exit_code(), 7);
+        assert!(child_is_reaped(pid));
+    }
+
+    /// A terminal whose child never reads its input fills its own queue,
+    /// is told so at once, and is never allowed to block the thread that
+    /// serves every other Session.
+    #[test]
+    fn input_queue_is_bounded_per_session_and_never_blocks() {
+        let dir = short_dir("queue");
+        let core = test_core();
+        let mut registry = Registry::new().unwrap();
+        let mut raw = spawn_session(
+            &dir,
+            "raw",
+            &["/bin/sh", "-c", "stty raw -echo; exec /bin/sleep 300"],
+            core.handle.clone(),
+            core.journal_tx.clone(),
+            Vec::new(),
+        );
+        let master_fd = raw.session_mut().pty_fd_for_test();
+        wait_until(
+            "the slave to enter raw mode",
+            Duration::from_secs(5),
+            || pty_is_raw(master_fd),
+        );
+        let slot = SlotRef {
+            slot: 0,
+            generation: 1,
+        };
+        raw.session_mut().register(&mut registry, slot).unwrap();
+
+        assert_eq!(
+            raw.session_mut()
+                .submit_input(&mut registry, b"once".to_vec(), Some("w-1")),
+            Ok(true)
+        );
+        assert_eq!(
+            raw.session_mut()
+                .submit_input(&mut registry, b"once".to_vec(), Some("w-1")),
+            Ok(false),
+            "a retried write id is a duplicate"
+        );
+        assert_eq!(
+            raw.session_mut().write_id_snapshot(),
+            vec!["w-1".to_string()]
+        );
+
+        let began = Instant::now();
+        let chunk = vec![b'x'; 64 * 1024];
+        let mut refused = None;
+        for _ in 0..64 {
+            match raw
+                .session_mut()
+                .submit_input(&mut registry, chunk.clone(), None)
+            {
+                Ok(true) => {}
+                Ok(false) => unreachable!("no write id"),
+                Err(error) => {
+                    refused = Some(error);
+                    break;
+                }
+            }
+        }
+        let refused = refused.expect("a terminal that never reads fills its queue");
+        assert!(refused.contains("not accepting input"), "{refused}");
+        assert!(raw.session_mut().pending_input_len() <= PENDING_PTY_INPUT_MAX_BYTES);
+        assert!(
+            began.elapsed() < Duration::from_secs(2),
+            "the refusal was immediate, not a blocked write ({:?})",
+            began.elapsed()
+        );
+        let late = raw
+            .session_mut()
+            .submit_input(&mut registry, chunk.clone(), Some("w-2"));
+        assert!(late.is_err(), "{late:?}");
+        assert_eq!(
+            raw.session_mut().write_id_snapshot(),
+            vec!["w-1".to_string()],
+            "a refused write id is not recorded, so it stays retryable"
+        );
+        // The bound is on bytes, not a latch: a keystroke still fits.
+        assert_eq!(
+            raw.session_mut()
+                .submit_input(&mut registry, b"k".to_vec(), Some("w-3")),
+            Ok(true)
+        );
+
+        let _ = raw.shared.runtime.lock().unwrap().child.kill();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The child exits but a grandchild keeps the slave open, so the PTY
+    /// never reaches EOF. The reactor's process watch ends the Session
+    /// anyway and the teardown reaps the child.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn child_exit_is_observed_without_pty_eof_and_the_child_is_reaped() {
+        let dir = short_dir("watch");
+        let mut core = test_core();
+        let mut session = spawn_session(
+            &dir,
+            "bg",
+            // The grandchild ignores the HUP the master's close sends at
+            // teardown, so its survival proves the Session ended on the
+            // child's exit and not on PTY EOF.
+            &[
+                "/bin/sh",
+                "-c",
+                "trap '' HUP; sleep 60 & echo grandchild=$!; sleep 0.3; exit 3",
+            ],
+            core.handle.clone(),
+            core.journal_tx.clone(),
+            Vec::new(),
+        );
+        let slot = core.reactor.register(session.session_take()).unwrap();
+        assert!(
+            core.reactor
+                .process_watches
+                .values()
+                .any(|watch| watch.slot == slot && watch.pid == session.child_pid),
+            "an owned child is watched for exit at registration"
+        );
+
+        let mut last_tick = Instant::now();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while core.reactor.sessions[slot.slot].is_some() {
+            assert!(
+                Instant::now() < deadline,
+                "the Session did not end when its child exited"
+            );
+            core.reactor
+                .run_once(Duration::from_millis(50), &mut last_tick);
+        }
+        assert_eq!(
+            session
+                .exited
+                .recv_timeout(Duration::from_secs(20))
+                .unwrap(),
+            Ok(())
+        );
+        pump(
+            &mut core.reactor,
+            "the slot to be released",
+            Duration::from_secs(10),
+            |r| r.free_slots.contains(&slot.slot),
+        );
+        assert!(child_is_reaped(session.child_pid), "no zombie child");
+
+        // The grandchild still holds the slave: EOF is not what ended it.
+        let journal = std::fs::read(&session.output_path).unwrap();
+        let text = String::from_utf8_lossy(&journal);
+        let grandchild: u32 = text
+            .split("grandchild=")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|digits| digits.parse().ok())
+            .expect("the shell printed its background child's pid");
+        assert!(
+            unsafe { libc::kill(grandchild as libc::pid_t, 0) } == 0,
+            "the grandchild is still running"
+        );
+        let _ = unsafe { libc::kill(grandchild as libc::pid_t, libc::SIGKILL) };
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/unpeel-core/src/session_host.rs
+++ b/crates/unpeel-core/src/session_host.rs
@@ -771,7 +771,6 @@ pub(crate) struct HostRuntime {
     /// then execing or renaming itself. Resume Agent uses its PID/start/PGID
     /// until a complete session scan proves the old job is gone.
     last_runtime_observation: Option<ActiveRuntimeObservation>,
-    recent_write_ids: RecentWriteIds,
 }
 
 #[cfg(unix)]
@@ -3452,21 +3451,27 @@ fn validate_write_id(write_id: Option<&str>) -> Result<Option<&str>, &'static st
 }
 
 #[derive(Default)]
-struct RecentWriteIds {
+pub(crate) struct RecentWriteIds {
     order: VecDeque<String>,
     seen: HashSet<String>,
 }
 
 impl RecentWriteIds {
-    fn contains(&self, write_id: &str) -> bool {
+    pub(crate) fn contains(&self, write_id: &str) -> bool {
         self.seen.contains(write_id)
     }
 
-    /// Record only after the PTY write succeeds. Keeping this history inside
-    /// `HostRuntime` lets the caller serialize check → write → record under
-    /// the same runtime lock; a failed first delivery therefore remains
-    /// retryable, and two racing transports cannot both apply the bytes.
-    fn record_applied(&mut self, write_id: &str) {
+    /// The ledger oldest first.
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> Vec<String> {
+        self.order.iter().cloned().collect()
+    }
+
+    /// Record only after the reactor has queued the bytes. The ledger lives
+    /// on the reactor-owned `SessionIo`, so check → queue → record is one
+    /// thread's sequence; a refused delivery therefore remains retryable,
+    /// and two racing transports cannot both apply the bytes.
+    pub(crate) fn record_applied(&mut self, write_id: &str) {
         if !self.seen.insert(write_id.to_string()) {
             return;
         }
@@ -6016,7 +6021,6 @@ pub(crate) fn start_host(
             pty_rows: initial_rows,
             shell_executable: PathBuf::from(&shell),
             last_runtime_observation: None,
-            recent_write_ids: RecentWriteIds::default(),
         }));
         // Raw local socket clients can bypass the lifecycle-file lock used by
         // `session_ops`; serialize in-place relaunches here as the final
@@ -6107,6 +6111,7 @@ pub(crate) fn start_host(
             pending_runtime_generation: Arc::clone(&pending_runtime_generation),
             reactor: services.reactor.clone(),
             slot: AtomicUsize::new(usize::MAX),
+            generation: AtomicU64::new(0),
         });
         let pressure = Arc::new(session_io::JournalBackpressure::default());
         let journal_id = session_io::next_journal_id();

--- a/crates/unpeel-core/src/session_io.rs
+++ b/crates/unpeel-core/src/session_io.rs
@@ -15,7 +15,7 @@
 //! scanners, broadcaster, and manifest helpers without widening their
 //! visibility.
 
-use super::core_reactor::{JournalMsg, ReactorHandle, Registry, TimerMsg};
+use super::core_reactor::{JournalMsg, ReactorHandle, Registry, SlotRef, TimerMsg};
 use super::*;
 use std::collections::HashMap;
 use std::io::ErrorKind;
@@ -34,7 +34,7 @@ const CLIENT_HANDSHAKE_MAX_BYTES: usize = 64 * 1024;
 /// Input frames wait here while the PTY's input queue is full (a stopped or
 /// non-reading foreground). Beyond this the input client is dropped rather
 /// than letting one wedged terminal grow the core without bound.
-const PENDING_PTY_INPUT_MAX_BYTES: usize = 1024 * 1024;
+pub(crate) const PENDING_PTY_INPUT_MAX_BYTES: usize = 1024 * 1024;
 
 /// Everything a control-socket command handler needs, previously threaded
 /// through `handle_client` as a dozen `Arc` parameters.
@@ -51,23 +51,46 @@ pub(crate) struct SessionShared {
     pub runtime_generation: Arc<AtomicU64>,
     pub pending_runtime_generation: Arc<AtomicU64>,
     /// Set by the reactor at registration; lets a handler running on a
-    /// transient thread (Kill) poke the reactor about this Session.
+    /// transient thread (Kill, Write) address the reactor about this
+    /// Session. Both halves of the `SlotRef` are stored before the reactor
+    /// acks the registration, so no other thread can observe a torn pair.
     pub reactor: ReactorHandle,
     pub slot: AtomicUsize,
+    pub generation: AtomicU64,
 }
 
 impl SessionShared {
-    /// Ask the reactor to revisit this Session (after `running` flipped).
+    /// Ask the reactor to revisit this Session (after `running` flipped, or
+    /// once an agent restart released the input queue).
     pub(crate) fn wake(&self) {
-        self.reactor.wake_session(self.slot.load(Ordering::Acquire));
+        self.reactor.wake_session(self.slot_ref());
+    }
+
+    pub(crate) fn slot_ref(&self) -> SlotRef {
+        SlotRef {
+            slot: self.slot.load(Ordering::Acquire),
+            generation: self.generation.load(Ordering::Acquire),
+        }
+    }
+
+    fn set_slot_ref(&self, slot: SlotRef) {
+        self.slot.store(slot.slot, Ordering::Release);
+        self.generation.store(slot.generation, Ordering::Release);
     }
 }
 
-/// The PTY master writer. Every write path (client Write, StreamInput,
-/// query answers, resume-in-place) goes through `HostRuntime.writer`; the
-/// master fd is non-blocking so the reactor can never stall on it, and this
-/// wrapper restores blocking `write_all` semantics for the transient-thread
-/// paths by waiting for `POLLOUT` between attempts.
+/// Longest a transient thread may sit in a blocking PTY write. The reactor
+/// never uses this path (it writes through the bounded input queue); the
+/// in-place agent relaunch does, and a terminal that has stopped reading
+/// must fail that relaunch instead of pinning its lock forever.
+const PTY_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The PTY master writer held by `HostRuntime`. The master fd is
+/// non-blocking; this wrapper restores bounded blocking `write_all`
+/// semantics for the transient-thread paths that still write directly
+/// (resume-in-place) by waiting for `POLLOUT` between attempts, up to
+/// `PTY_WRITE_TIMEOUT`. Client input and query answers never come through
+/// here: the reactor queues them (`SessionIo::drain_pending_input`).
 pub(crate) struct PtyWriter {
     inner: Box<dyn Write + Send>,
     fd: RawFd,
@@ -76,11 +99,6 @@ pub(crate) struct PtyWriter {
 impl PtyWriter {
     pub(crate) fn new(inner: Box<dyn Write + Send>, fd: RawFd) -> Self {
         Self { inner, fd }
-    }
-
-    /// One non-blocking attempt; the reactor queues the remainder.
-    pub(crate) fn try_write(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(data)
     }
 
     /// Detach the underlying writer without running its destructor.
@@ -105,9 +123,18 @@ impl PtyWriter {
 
 impl Write for PtyWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let deadline = Instant::now() + PTY_WRITE_TIMEOUT;
         loop {
             match self.inner.write(buf) {
-                Err(error) if error.kind() == ErrorKind::WouldBlock => self.wait_writable(250),
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(std::io::Error::new(
+                            ErrorKind::TimedOut,
+                            "terminal is not accepting input",
+                        ));
+                    }
+                    self.wait_writable(250);
+                }
                 Err(error) if error.kind() == ErrorKind::Interrupted => continue,
                 result => return result,
             }
@@ -151,9 +178,20 @@ pub(crate) struct SessionExitPlan {
 pub(crate) struct JournalBackpressure {
     pub backlog: AtomicUsize,
     pub paused: AtomicBool,
-    /// Reactor slot, set at registration so the writer can address the
-    /// Session in `Control` messages.
+    /// Reactor identity, set at registration so the writer can address
+    /// the Session in `Control` messages (and only this occupant of the
+    /// slot: see `SlotRef`).
     pub slot: AtomicUsize,
+    pub generation: AtomicU64,
+}
+
+impl JournalBackpressure {
+    pub(crate) fn slot_ref(&self) -> SlotRef {
+        SlotRef {
+            slot: self.slot.load(Ordering::Acquire),
+            generation: self.generation.load(Ordering::Acquire),
+        }
+    }
 }
 
 static NEXT_JOURNAL_ID: AtomicU64 = AtomicU64::new(1);
@@ -234,6 +272,15 @@ pub(crate) struct SessionIo {
     handing_off: bool,
     /// Last PTY output; idle buffers are released a tick after this.
     last_output_at: Instant,
+    /// Write-id ledger for one-shot `Write` commands. Reactor-owned so the
+    /// check → queue → record sequence is trivially atomic (one thread).
+    recent_write_ids: RecentWriteIds,
+    /// The child to watch for exit (pid, where its status lands). An owned
+    /// child's status also comes from `waitpid` at teardown; a handed-over
+    /// child's only from here.
+    child_watch: Option<(u32, Arc<Mutex<Option<portable_pty::ExitStatus>>>)>,
+    /// The reactor's token for that watch while it is armed.
+    child_watch_token: Option<u64>,
 }
 
 /// A Session with no PTY output for this long releases its recent ring,
@@ -282,11 +329,49 @@ impl SessionIo {
             timer_jobs: Some(timer_jobs),
             exit: Some(exit),
             ended: false,
+            child_watch: job_seed.pid.map(|pid| (pid, Arc::new(Mutex::new(None)))),
             job_seed,
             adopted_clients: Vec::new(),
             handing_off: false,
             last_output_at: Instant::now(),
+            recent_write_ids: RecentWriteIds::default(),
+            child_watch_token: None,
         }
+    }
+
+    pub(crate) fn slot_ref(&self) -> SlotRef {
+        self.shared.slot_ref()
+    }
+
+    /// The child the reactor should watch for exit, if any.
+    pub(crate) fn child_watch(
+        &self,
+    ) -> Option<(u32, Arc<Mutex<Option<portable_pty::ExitStatus>>>)> {
+        self.child_watch
+            .as_ref()
+            .map(|(pid, slot)| (*pid, Arc::clone(slot)))
+    }
+
+    /// A handed-over child: its status slot is the `HandedOverChild`'s.
+    pub(crate) fn set_child_watch(
+        &mut self,
+        pid: u32,
+        exit_slot: Arc<Mutex<Option<portable_pty::ExitStatus>>>,
+    ) {
+        self.child_watch = Some((pid, exit_slot));
+    }
+
+    pub(crate) fn set_child_watch_token(&mut self, token: u64) {
+        self.child_watch_token = Some(token);
+    }
+
+    pub(crate) fn child_watch_token(&self) -> Option<u64> {
+        self.child_watch_token
+    }
+
+    /// The watch fired (one-shot); nothing to unregister at teardown.
+    pub(crate) fn clear_child_watch(&mut self) {
+        self.child_watch_token = None;
     }
 
     /// Idle-tick diet: a quiet Session keeps only its state, no buffers. The
@@ -338,9 +423,18 @@ impl SessionIo {
     // ───────────────────────── registration ─────────────────────────
 
     /// Register the PTY master and the listener with the reactor's poller.
-    pub(crate) fn register(&mut self, registry: &mut Registry, slot: usize) -> Result<(), String> {
-        self.shared.slot.store(slot, Ordering::Release);
+    pub(crate) fn register(
+        &mut self,
+        registry: &mut Registry,
+        slot_ref: SlotRef,
+    ) -> Result<(), String> {
+        let slot = slot_ref.slot;
+        self.shared.set_slot_ref(slot_ref);
         self.journal.pressure.slot.store(slot, Ordering::Release);
+        self.journal
+            .pressure
+            .generation
+            .store(slot_ref.generation, Ordering::Release);
         self.pty_token = registry.add(self.pty_fd, slot, TokenKind::Pty, true, false)?;
         self.pty_read_interest = true;
         if let Some(listener) = &self.listener {
@@ -442,7 +536,7 @@ impl SessionIo {
         let outcome = match read {
             Ok(0) => ReadOutcome::Ended,
             Ok(n) => {
-                self.process_pty_bytes(&scratch[..n]);
+                self.process_pty_bytes(registry, &scratch[..n]);
                 self.apply_journal_backpressure(registry);
                 ReadOutcome::Continue
             }
@@ -487,7 +581,7 @@ impl SessionIo {
         ReadOutcome::Continue
     }
 
-    fn process_pty_bytes(&mut self, bytes: &[u8]) {
+    fn process_pty_bytes(&mut self, registry: &mut Registry, bytes: &[u8]) {
         let shared = Arc::clone(&self.shared);
         // Answer terminal queries at the host and excise them from the
         // stream: DA1 always, and the wider probe set whenever no answering
@@ -500,16 +594,16 @@ impl SessionIo {
         let (chunk, host_queries) = self.query_scanner.scan(bytes, intercept_probes);
         if !host_queries.is_empty() {
             let cursor = shared.viewport.lock().unwrap().cursor_position();
-            let mut guard = shared.runtime.lock().unwrap();
+            let mut answers: Vec<u8> = Vec::new();
             for query in &host_queries {
-                let _ = match query {
+                match query {
                     HostAnsweredQuery::Da1 => {
-                        guard.writer.write_all(PRIMARY_DEVICE_ATTRIBUTES_RESPONSE)
+                        answers.extend_from_slice(PRIMARY_DEVICE_ATTRIBUTES_RESPONSE)
                     }
-                    HostAnsweredQuery::CursorPosition => guard
-                        .writer
-                        .write_all(format!("\x1b[{};{}R", cursor.0 + 1, cursor.1 + 1).as_bytes()),
-                    HostAnsweredQuery::KittyFlags => guard.writer.write_all(b"\x1b[?0u"),
+                    HostAnsweredQuery::CursorPosition => answers.extend_from_slice(
+                        format!("\x1b[{};{}R", cursor.0 + 1, cursor.1 + 1).as_bytes(),
+                    ),
+                    HostAnsweredQuery::KittyFlags => answers.extend_from_slice(b"\x1b[?0u"),
                     HostAnsweredQuery::OscColor { code } => {
                         let rgb = match (code, self.dark_mode) {
                             (10, true) => "f3f3/f5f5/fbfb",
@@ -517,22 +611,30 @@ impl SessionIo {
                             (_, true) => "1a1a/1a1a/1f1f",
                             (_, false) => "ffff/ffff/ffff",
                         };
-                        guard
-                            .writer
-                            .write_all(format!("\x1b]{code};rgb:{rgb}\x07").as_bytes())
+                        answers.extend_from_slice(format!("\x1b]{code};rgb:{rgb}\x07").as_bytes())
                     }
                     HostAnsweredQuery::OscPalette { index } => {
                         let (r, g, b) = xterm_palette_rgb(*index);
-                        guard.writer.write_all(
+                        answers.extend_from_slice(
                             format!(
                                 "\x1b]4;{index};rgb:{r:02x}{r:02x}/{g:02x}{g:02x}/{b:02x}{b:02x}\x07"
                             )
                             .as_bytes(),
                         )
                     }
-                };
+                }
             }
-            let _ = guard.writer.flush();
+            // Answers are input like any other: through this Session's
+            // bounded queue, never a blocking write on the reactor. A child
+            // that floods queries without reading its replies fills only
+            // its own queue (the overflow is logged and dropped) and never
+            // stalls a sibling.
+            if let Err(error) = self.queue_pty_input(registry, &answers) {
+                log::warn!(
+                    "{}: dropping terminal query answers: {error}",
+                    shared.session_id
+                );
+            }
         }
         if chunk.is_empty() {
             return;
@@ -589,52 +691,124 @@ impl SessionIo {
     // ───────────────────────── PTY input ─────────────────────────
 
     /// Queue bytes for the PTY, writing what fits right now. Order between
-    /// queued bytes and later frames is preserved by always appending.
-    fn write_pty_input(&mut self, registry: &mut Registry, data: &[u8]) -> Result<(), String> {
+    /// queued bytes and later frames is preserved by always appending. The
+    /// queue is bounded per Session (`PENDING_PTY_INPUT_MAX_BYTES`): bytes
+    /// that do not fit are refused with an error and nothing already
+    /// queued is lost, so a terminal that stopped reading costs at most
+    /// that much memory and only its own writers are told to back off.
+    fn queue_pty_input(&mut self, registry: &mut Registry, data: &[u8]) -> Result<(), String> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        if self.pending_input.len() + data.len() > PENDING_PTY_INPUT_MAX_BYTES {
+            // Make room if the PTY has drained meanwhile, then re-check.
+            self.drain_pending_input(registry)?;
+            if self.pending_input.len() + data.len() > PENDING_PTY_INPUT_MAX_BYTES {
+                return Err(format!(
+                    "Write error: terminal is not accepting input ({} bytes still queued)",
+                    self.pending_input.len()
+                ));
+            }
+        }
         self.pending_input.extend(data);
         self.drain_pending_input(registry)
     }
 
+    /// Streaming-client input: queue, or drop the client when its terminal
+    /// has stopped reading and the queue is full (as before).
+    fn write_pty_input(&mut self, registry: &mut Registry, data: &[u8]) -> Result<(), String> {
+        self.queue_pty_input(registry, data)
+    }
+
+    /// A one-shot `Write` command arriving via the reactor. Duplicate ids
+    /// (a retried delivery) are answered `Ok(false)` without queueing;
+    /// otherwise the bytes are queued and the id recorded, so a retry of a
+    /// write the reactor accepted is never applied twice, even if the
+    /// caller's reply was lost.
+    pub(crate) fn submit_input(
+        &mut self,
+        registry: &mut Registry,
+        data: Vec<u8>,
+        write_id: Option<&str>,
+    ) -> Result<bool, String> {
+        if !self.shared.running.load(Ordering::Relaxed) || self.ended {
+            return Err("Write error: session has stopped".into());
+        }
+        if let Some(id) = write_id {
+            if self.recent_write_ids.contains(id) {
+                return Ok(false);
+            }
+        }
+        self.queue_pty_input(registry, &data)?;
+        if let Some(id) = write_id {
+            self.recent_write_ids.record_applied(id);
+        }
+        Ok(true)
+    }
+
+    /// Write queued input straight to the master fd, as much as the kernel
+    /// takes right now, and arm the writable event for the rest. Never
+    /// blocks and never takes `HostRuntime`'s lock: a transient command
+    /// thread holding that lock across a slow operation cannot stop the
+    /// reactor. An in-place agent relaunch holds `agent_restart_lock` for
+    /// its duration; input queued meanwhile stays queued (the relaunch
+    /// wakes this Session when it is done, and the idle tick retries too)
+    /// so it can never land between the stop and the new command.
     pub(crate) fn drain_pending_input(&mut self, registry: &mut Registry) -> Result<(), String> {
         if self.pending_input.is_empty() {
+            let read = self.pty_read_interest;
+            self.set_pty_interest(registry, read, false);
             return Ok(());
         }
         let shared = Arc::clone(&self.shared);
+        let restart_guard = match shared.agent_restart_lock.try_lock() {
+            Ok(guard) => guard,
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => {
+                // Deferred, not blocked: no writable interest (level-triggered
+                // POLLOUT would spin), the restart's wake or the idle tick
+                // brings us back.
+                let read = self.pty_read_interest;
+                self.set_pty_interest(registry, read, false);
+                return Ok(());
+            }
+        };
         let mut wrote_any = false;
-        let blocked = {
-            let _restart_guard = shared
-                .agent_restart_lock
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let mut guard = shared.runtime.lock().unwrap();
-            let mut blocked = false;
-            while !self.pending_input.is_empty() {
-                let (head, _) = self.pending_input.as_slices();
-                match guard.writer.try_write(head) {
-                    Ok(0) => {
-                        blocked = true;
-                        break;
-                    }
-                    Ok(n) => {
-                        self.pending_input.drain(..n);
-                        wrote_any = true;
-                    }
-                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                        blocked = true;
-                        break;
-                    }
-                    Err(error) if error.kind() == ErrorKind::Interrupted => continue,
-                    Err(error) => return Err(format!("Write error: {error}")),
+        let mut blocked = false;
+        while !self.pending_input.is_empty() {
+            let (head, _) = self.pending_input.as_slices();
+            let n = unsafe {
+                libc::write(
+                    self.pty_fd,
+                    head.as_ptr() as *const libc::c_void,
+                    head.len(),
+                )
+            };
+            if n > 0 {
+                self.pending_input.drain(..n as usize);
+                wrote_any = true;
+                continue;
+            }
+            if n == 0 {
+                blocked = true;
+                break;
+            }
+            let error = std::io::Error::last_os_error();
+            match error.kind() {
+                ErrorKind::WouldBlock => {
+                    blocked = true;
+                    break;
+                }
+                ErrorKind::Interrupted => continue,
+                _ => {
+                    drop(restart_guard);
+                    return Err(format!("Write error: {error}"));
                 }
             }
-            blocked
-        };
+        }
+        drop(restart_guard);
         if wrote_any {
             mark_input_written(&shared.session_id, &shared.has_been_written_to);
-        }
-        if blocked && self.pending_input.len() > PENDING_PTY_INPUT_MAX_BYTES {
-            self.pending_input.clear();
-            return Err("PTY input queue stalled; dropping buffered input".into());
         }
         let read = self.pty_read_interest;
         self.set_pty_interest(registry, read, blocked);
@@ -1092,13 +1266,17 @@ impl SessionIo {
         for client in clients {
             self.close_client(registry, client);
         }
-        let slot = self.shared.slot.load(Ordering::Acquire);
+        let slot = self.shared.slot_ref();
         SessionTeardown {
             shared: Arc::clone(&self.shared),
             slot,
             journal_tx: self.journal.tx.clone(),
             journal_id: self.journal.id,
             exit: self.exit.take(),
+            child_exit: self
+                .child_watch
+                .as_ref()
+                .map(|(_, exit_slot)| Arc::clone(exit_slot)),
             // Dropping the reader/master dups here; the runtime keeps the
             // master for try_wait/kill until the teardown thread is done.
             _pty_reader: self.pty_reader,
@@ -1118,17 +1296,91 @@ pub(crate) enum TokenKind {
 
 pub(crate) struct SessionTeardown {
     pub shared: Arc<SessionShared>,
-    pub slot: usize,
+    pub slot: SlotRef,
     pub journal_tx: mpsc::Sender<JournalMsg>,
     pub journal_id: u64,
     pub exit: Option<SessionExitPlan>,
+    /// Where the reactor's process watch put the child's status, if it
+    /// fired before the teardown.
+    pub child_exit: Option<Arc<Mutex<Option<portable_pty::ExitStatus>>>>,
     _pty_reader: Box<dyn Read + Send>,
+}
+
+/// Grace between SIGTERM and SIGKILL when reaping a child that outlived
+/// its Session.
+const CHILD_REAP_TERM_GRACE: Duration = Duration::from_millis(1500);
+/// Longest the teardown waits for a SIGKILLed child to be reapable (a
+/// process stuck in an uninterruptible kernel wait can exceed this; the
+/// exit code is then recorded as unknown, never a made-up number).
+const CHILD_REAP_KILL_WAIT: Duration = Duration::from_secs(5);
+const CHILD_REAP_POLL: Duration = Duration::from_millis(20);
+
+/// Reap the Session's child at teardown. A child that is already gone is
+/// waited on right away; one still alive is asked to leave (SIGTERM), then
+/// forced (SIGKILL), and waited on within a bound. Signals go only to a
+/// pid whose kernel start time matches what the Session recorded (`pid` is
+/// an unreaped child here, so it cannot have been recycled, but a
+/// handed-over child is not ours and is checked exactly like every other
+/// recorded pid). Returns the exit status, or `None` when the child could
+/// not be observed exiting in time.
+pub(crate) fn reap_hosted_child(
+    child: &mut dyn portable_pty::Child,
+    pid_started_at: Option<u64>,
+) -> Option<portable_pty::ExitStatus> {
+    if let Ok(Some(status)) = child.try_wait() {
+        return Some(status);
+    }
+    let pid = child.process_id()?;
+    let signal = |child: &mut dyn portable_pty::Child, signal: libc::c_int| {
+        match recorded_pid_identity(pid, pid_started_at) {
+            PidIdentity::Matches => {
+                let _ = unsafe { libc::kill(pid as libc::pid_t, signal) };
+            }
+            // No recorded start time to prove the pid: let the handle use
+            // its own notion of ownership (portable-pty's SIGHUP to a child
+            // that is unreaped and therefore still ours; a handed-over
+            // child's identity-checked kill).
+            PidIdentity::Unknown => {
+                let _ = child.kill();
+            }
+            PidIdentity::NotOurs => {}
+        }
+    };
+    let wait_until = |child: &mut dyn portable_pty::Child, budget: Duration| {
+        let deadline = Instant::now() + budget;
+        loop {
+            if let Ok(Some(status)) = child.try_wait() {
+                return Some(status);
+            }
+            if recorded_pid_identity(pid, pid_started_at) == PidIdentity::NotOurs {
+                // Gone (a handed-over child that was never ours to wait on,
+                // or a stranger in a recycled pid): nothing left to reap.
+                return None;
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            thread::sleep(CHILD_REAP_POLL);
+        }
+    };
+    signal(child, libc::SIGTERM);
+    if let Some(status) = wait_until(child, CHILD_REAP_TERM_GRACE) {
+        return Some(status);
+    }
+    if recorded_pid_identity(pid, pid_started_at) == PidIdentity::NotOurs {
+        return None;
+    }
+    signal(child, libc::SIGKILL);
+    wait_until(child, CHILD_REAP_KILL_WAIT)
 }
 
 impl SessionTeardown {
     /// The old epilogue after the reader loop: journal flushed and closed
-    /// BEFORE the exited manifest, timer jobs retired BEFORE it too, then the
-    /// exit edge merged under the manifest lock and the sockets removed.
+    /// BEFORE the exited manifest, timer jobs retired BEFORE it too, the
+    /// child reaped (so the core never accumulates zombies and the exit
+    /// code is the real one), then the exit edge merged under the manifest
+    /// lock and the sockets removed. Always ends by telling the reactor the
+    /// slot is free.
     pub(crate) fn run(self, timer_tx: &mpsc::Sender<TimerMsg>, outcome: Result<(), String>) {
         let SessionTeardown {
             shared,
@@ -1136,8 +1388,38 @@ impl SessionTeardown {
             journal_tx,
             journal_id,
             exit,
+            child_exit,
             _pty_reader,
         } = self;
+        let reactor = shared.reactor.clone();
+        Self::run_epilogue(
+            shared,
+            slot,
+            journal_tx,
+            journal_id,
+            exit,
+            child_exit,
+            _pty_reader,
+            timer_tx,
+            outcome,
+        );
+        // Everything this Session owned is freed now; the reactor may
+        // reuse the slot and hand the pages back on its next idle tick.
+        reactor.session_ended(slot);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_epilogue(
+        shared: Arc<SessionShared>,
+        slot: SlotRef,
+        journal_tx: mpsc::Sender<JournalMsg>,
+        journal_id: u64,
+        exit: Option<SessionExitPlan>,
+        child_exit: Option<Arc<Mutex<Option<portable_pty::ExitStatus>>>>,
+        pty_reader: Box<dyn Read + Send>,
+        timer_tx: &mpsc::Sender<TimerMsg>,
+        outcome: Result<(), String>,
+    ) {
         let mut result = outcome;
 
         let (ack_tx, ack_rx) = mpsc::channel();
@@ -1168,17 +1450,18 @@ impl SessionTeardown {
         }
 
         let Some(exit) = exit else {
+            drop(pty_reader);
             return;
         };
-        let exit_code = shared
-            .runtime
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .child
-            .try_wait()
-            .ok()
-            .flatten()
-            .map(|status| status.exit_code() as i32);
+        let exit_code = {
+            let mut runtime = shared
+                .runtime
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            reap_hosted_child(runtime.child.as_mut(), exit.pid_started_at)
+                .or_else(|| child_exit.and_then(|slot| slot.lock().ok()?.clone()))
+                .map(|status| status.exit_code() as i32)
+        };
         let input_was_written = shared.has_been_written_to.load(Ordering::Relaxed);
         let host_build_id = exit.host_build_id.clone();
         let _ = update_manifest_session(&shared.session_id, |manifest| {
@@ -1201,14 +1484,10 @@ impl SessionTeardown {
         let _ = fs::remove_file(&exit.session_socket_path);
         // Release the PTY master and child handle now that the exit edge is
         // published; the runtime Arc may still be held by a late one-shot
-        // command thread, which then finds a closed child.
+        // command thread, which then finds a reaped child.
         (exit.on_exit)(result);
-        let reactor = shared.reactor.clone();
         drop(shared);
-        drop(_pty_reader);
-        // Everything this Session owned is freed now; let the reactor hand
-        // the pages back once its next idle tick finds no teardown racing.
-        reactor.session_ended();
+        drop(pty_reader);
     }
 }
 
@@ -1309,45 +1588,50 @@ pub(crate) fn dispatch_client_command(
                     viewport: None,
                 },
                 Ok(write_id) => {
-                    // Serialize idempotency check → PTY write → history
-                    // commit. A failed write is deliberately not recorded, so
-                    // an HTTP retry can still deliver it; a racing retry waits
-                    // on this same lock and observes the committed id after
-                    // the first successful write.
-                    let applied = {
-                        let _restart_guard = agent_restart_lock
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner());
-                        let mut guard = runtime.lock().unwrap();
-                        if write_id.is_some_and(|id| guard.recent_write_ids.contains(id)) {
-                            false
-                        } else {
-                            guard
-                                .writer
-                                .write_all(data.as_bytes())
-                                .map_err(|e| format!("Write error: {e}"))?;
-                            if let Some(write_id) = write_id {
-                                guard.recent_write_ids.record_applied(write_id);
+                    // The reactor owns the PTY: it checks the id, queues the
+                    // bytes into this Session's bounded input queue, and
+                    // records the id, all on its own thread (so a racing
+                    // retry observes the committed id). A refused write (queue
+                    // full, Session gone) is not recorded and stays
+                    // retryable. This thread holds no lock the reactor needs
+                    // while it waits, and a wedged terminal answers with an
+                    // error instead of parking the caller and the core.
+                    // A refusal (queue full, Session gone) is an answer,
+                    // not a dropped connection: the caller reads the error
+                    // and decides whether to retry.
+                    match shared.reactor.submit_input(
+                        shared.slot_ref(),
+                        data.as_bytes().to_vec(),
+                        write_id.map(|id| id.to_string()),
+                    ) {
+                        Err(error) => SessionHostResponse {
+                            ok: false,
+                            error: Some(if error.starts_with("Write error") {
+                                error
+                            } else {
+                                format!("Write error: {error}")
+                            }),
+                            viewport: None,
+                        },
+                        Ok(applied) => {
+                            if applied {
+                                mark_input_written(session_id, &shared.has_been_written_to);
+                                // Auto-title from the first submitted prompt
+                                // for clients that write straight to the
+                                // control socket (native attach, MCP).
+                                maybe_auto_title_from_input(
+                                    session_id,
+                                    data.as_bytes(),
+                                    &shared.title_buffer,
+                                    &shared.title_done,
+                                );
                             }
-                            true
+                            SessionHostResponse {
+                                ok: true,
+                                error: None,
+                                viewport: None,
+                            }
                         }
-                    };
-                    if applied {
-                        mark_input_written(session_id, &shared.has_been_written_to);
-                        // Auto-title from the first submitted prompt for
-                        // clients that write straight to the control socket
-                        // (native attach, MCP).
-                        maybe_auto_title_from_input(
-                            session_id,
-                            data.as_bytes(),
-                            &shared.title_buffer,
-                            &shared.title_done,
-                        );
-                    }
-                    SessionHostResponse {
-                        ok: true,
-                        error: None,
-                        viewport: None,
                     }
                 }
             }
@@ -1424,6 +1708,9 @@ pub(crate) fn dispatch_client_command(
                     Err("An agent restart is already in progress".into())
                 }
             };
+            // Input queued while the restart held `agent_restart_lock` was
+            // deferred by the reactor; deliver it now.
+            shared.wake();
             match result {
                 Ok(()) => SessionHostResponse {
                     ok: true,
@@ -1949,7 +2236,6 @@ pub(crate) fn rebuild_from_handoff(
         pty_rows: meta.pty_rows,
         shell_executable: PathBuf::from(&meta.shell),
         last_runtime_observation: None,
-        recent_write_ids: RecentWriteIds::default(),
     }));
 
     let mut viewport_state = TerminalViewportState::new(meta.snapshot_cols, meta.snapshot_rows);
@@ -1999,6 +2285,7 @@ pub(crate) fn rebuild_from_handoff(
         pending_runtime_generation: Arc::new(AtomicU64::new(meta.pending_runtime_generation)),
         reactor: services.reactor.clone(),
         slot: AtomicUsize::new(usize::MAX),
+        generation: AtomicU64::new(0),
     });
     let pressure = Arc::new(JournalBackpressure::default());
     let journal_id = next_journal_id();
@@ -2057,6 +2344,10 @@ pub(crate) fn rebuild_from_handoff(
     );
     session.agent_title_settled = meta.agent_title_settled;
     session.pending_input = meta.pending_pty_input.iter().copied().collect();
+    // The reactor's process watch feeds the `HandedOverChild`'s status slot.
+    if let Some(pid) = child_pid {
+        session.set_child_watch(pid, Arc::clone(&exit_slot));
+    }
     let clients: Vec<(UnixStream, ClientHandoff)> = client_fds
         .into_iter()
         .zip(meta.clients)
@@ -2099,4 +2390,203 @@ pub(crate) fn record_child_exit(
         _ => portable_pty::ExitStatus::with_exit_code(0),
     };
     *slot.lock().unwrap() = Some(status);
+}
+
+#[cfg(test)]
+impl SessionIo {
+    pub(crate) fn pending_input_len(&self) -> usize {
+        self.pending_input.len()
+    }
+
+    pub(crate) fn write_id_snapshot(&self) -> Vec<String> {
+        self.recent_write_ids.snapshot()
+    }
+
+    pub(crate) fn pty_fd_for_test(&self) -> RawFd {
+        self.pty_fd
+    }
+}
+
+/// A hosted Session built the way `run_host` builds one, minus the launch,
+/// manifest, and hook steps: a real PTY with a real child, a real control
+/// socket in a short temp dir, and a journal on the given writer thread.
+/// `has_been_written_to` and `title_done` start true so nothing here ever
+/// reaches a manifest through the input paths.
+#[cfg(all(test, unix))]
+pub(crate) mod test_support {
+    use super::*;
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+    pub(crate) struct TestSession {
+        /// `None` once handed to a reactor (`session_take`).
+        pub session: Option<SessionIo>,
+        pub shared: Arc<SessionShared>,
+        pub child_pid: u32,
+        pub child_started_at: Option<u64>,
+        pub output_path: PathBuf,
+        /// The `on_exit` outcome, sent from the teardown thread.
+        pub exited: mpsc::Receiver<Result<(), String>>,
+    }
+
+    impl TestSession {
+        pub(crate) fn session_take(&mut self) -> SessionIo {
+            self.session.take().expect("session not yet handed over")
+        }
+
+        pub(crate) fn session_mut(&mut self) -> &mut SessionIo {
+            self.session.as_mut().expect("session not yet handed over")
+        }
+    }
+
+    /// Unix socket paths are capped near 104 bytes; keep the dir short.
+    pub(crate) fn short_dir(tag: &str) -> PathBuf {
+        let dir = PathBuf::from(format!("/tmp/uio-{}-{tag}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    pub(crate) fn spawn_session(
+        dir: &Path,
+        id: &str,
+        command: &[&str],
+        reactor: ReactorHandle,
+        journal_tx: mpsc::Sender<JournalMsg>,
+        timer_jobs: Vec<HostTimerJob>,
+    ) -> TestSession {
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let mut cmd = CommandBuilder::new(command[0]);
+        cmd.args(&command[1..]);
+        let child = pair.slave.spawn_command(cmd).expect("spawn child");
+        drop(pair.slave);
+        let writer = pair.master.take_writer().expect("writer");
+        let pty_fd = pair.master.as_raw_fd().expect("master fd");
+        let reader = pair.master.try_clone_reader().expect("reader");
+        set_nonblocking(pty_fd, true).expect("non-blocking master");
+        let writer = PtyWriter::new(writer, pty_fd);
+        let child_pid = child.process_id().expect("child pid");
+        let child_started_at = process_start_time_ms(child_pid);
+        let runtime = Arc::new(Mutex::new(HostRuntime {
+            master: pair.master,
+            writer,
+            child,
+            pty_cols: 80,
+            pty_rows: 24,
+            shell_executable: PathBuf::from(command[0]),
+            last_runtime_observation: None,
+        }));
+        let viewport = Arc::new(Mutex::new(TerminalViewportState::new(80, 24)));
+        let broadcaster = Arc::new(Mutex::new(OutputBroadcaster::at_offset(0)));
+        let socket = dir.join(format!("{id}.sock"));
+        let listener = UnixListener::bind(&socket).expect("bind session socket");
+        listener.set_nonblocking(true).unwrap();
+        let shared = Arc::new(SessionShared {
+            session_id: id.to_string(),
+            runtime: Arc::clone(&runtime),
+            viewport,
+            running: Arc::new(AtomicBool::new(true)),
+            broadcaster,
+            title_buffer: Arc::new(Mutex::new(String::new())),
+            title_done: Arc::new(AtomicBool::new(true)),
+            has_been_written_to: Arc::new(AtomicBool::new(true)),
+            agent_restart_lock: Arc::new(Mutex::new(())),
+            runtime_generation: Arc::new(AtomicU64::new(0)),
+            pending_runtime_generation: Arc::new(AtomicU64::new(0)),
+            reactor,
+            slot: AtomicUsize::new(usize::MAX),
+            generation: AtomicU64::new(0),
+        });
+        let output_path = dir.join(format!("{id}.output.bin"));
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&output_path)
+            .unwrap();
+        let retained =
+            RetainedOutputWriter::new(file, output_path.clone(), 0, 1 << 20, 1 << 20).unwrap();
+        let pressure = Arc::new(JournalBackpressure::default());
+        let journal_id = next_journal_id();
+        journal_tx
+            .send(JournalMsg::Open {
+                id: journal_id,
+                writer: retained,
+                pressure: Arc::clone(&pressure),
+            })
+            .expect("journal writer is running");
+        let journal = JournalHandle {
+            id: journal_id,
+            tx: journal_tx,
+            pressure,
+            failed: Arc::new(AtomicBool::new(false)),
+        };
+        let (exit_tx, exited) = mpsc::channel();
+        let exit = SessionExitPlan {
+            pid: Some(child_pid),
+            pid_started_at: child_started_at,
+            host_build_id: None,
+            session_socket_path: socket,
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let session = SessionIo::new(
+            Arc::clone(&shared),
+            pty_fd,
+            reader,
+            listener,
+            true,
+            journal,
+            timer_jobs,
+            exit,
+            JobSeed {
+                command: command.join(" "),
+                shell: command[0].to_string(),
+                pid: Some(child_pid),
+                pid_started_at: child_started_at,
+            },
+        );
+        TestSession {
+            session: Some(session),
+            shared,
+            child_pid,
+            child_started_at,
+            output_path,
+            exited,
+        }
+    }
+
+    pub(crate) fn wait_until(what: &str, timeout: Duration, mut predicate: impl FnMut() -> bool) {
+        let deadline = Instant::now() + timeout;
+        while !predicate() {
+            assert!(Instant::now() < deadline, "timed out waiting for {what}");
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    /// Whether a child this process spawned has been waited on: the kernel
+    /// then no longer knows the pid as our child (`ECHILD`). A zombie
+    /// answers with its status instead, which reaps it here and returns
+    /// `false` — the teardown did not.
+    pub(crate) fn child_is_reaped(pid: u32) -> bool {
+        let mut status = 0;
+        let rc = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+        rc == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD)
+    }
+
+    /// Whether the slave behind `master_fd` is in raw mode (no ICANON).
+    pub(crate) fn pty_is_raw(master_fd: RawFd) -> bool {
+        let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+        let ok = unsafe { libc::tcgetattr(master_fd, &mut termios) } == 0;
+        ok && (termios.c_lflag & libc::ICANON) == 0
+    }
 }

--- a/docs/agents/pty-core.md
+++ b/docs/agents/pty-core.md
@@ -129,21 +129,64 @@ short-lived thread per request; the reactor reads the JSON line, then hands
 the socket over. The `session.sock` protocol, `output.bin` semantics, hook
 env, and manifest fields are unchanged.
 
-The PTY master is `O_NONBLOCK`. `HostRuntime.writer` is a `PtyWriter` that
-restores blocking `write_all` for the transient-thread paths by waiting for
-`POLLOUT`; the reactor's `StreamInput` path writes what fits and queues the
-rest for the PTY's writable event (bounded at 1 MiB, then the input client
-is dropped).
+**Per-session input isolation.** The PTY master is `O_NONBLOCK` and the
+reactor is the only thread that writes it, always through that Session's
+bounded input queue (`SessionIo::drain_pending_input`: write what the
+kernel takes now, arm the writable event for the rest, 1 MiB cap per
+Session). `StreamInput` frames, one-shot `Write` commands
+(`Control::Input`, submitted from the command's transient thread and
+answered once queued), and the Host's own terminal-query answers (DA1,
+CPR, OSC colour) all go through it; nothing on the reactor thread ever
+blocks on a PTY, and no transient thread holds a lock the reactor needs
+across a blocking write (the reactor never takes `HostRuntime`'s lock for
+input). A terminal that stops reading fills only its own queue: further
+`Write`s to it are refused with `terminal is not accepting input`, a
+flooding stream client is dropped, query answers that do not fit are
+logged and dropped, and every sibling's `session.sock` keeps answering.
+The one remaining direct writer, the in-place agent relaunch, uses
+`PtyWriter` with a 5 s bound and holds `agent_restart_lock` meanwhile;
+input queued for that Session during the relaunch is deferred (never
+written between the stop and the new command) and drained on the
+relaunch's wake or the next idle tick. The `Write` idempotency ledger
+(`recent_write_ids`) lives on the reactor-owned `SessionIo`, so check →
+queue → record is one thread's sequence.
 
-Session end (PTY EOF/error, or Kill followed by a final drain) detaches the
-fds on the reactor and runs the old epilogue on a `session-exit` thread:
-journal flushed and closed, timer jobs retired, exit code, exited manifest
-under the manifest lock, sockets removed, then the owner's `on_exit`. The
-per-process `__session_host__` runs the same services with N = 1 and just
-blocks its main thread on that callback. After a teardown the reactor's
-next idle tick hands freed heap back to the OS
+**Slot identity.** A hosted Session is addressed by a `SlotRef` (slot +
+monotonic generation). Every cross-thread message about a Session
+(`Wake`, `Input`, `JournalDrained`, `JournalFailed`, `SessionEnded`,
+`TimerMsg::Add`/`Remove`) carries one, and the reactor and timer drop any
+whose generation is not the slot's current one. A slot leaves `sessions`
+at `end_session` but returns to `free_slots` only when the teardown
+thread reports `SessionEnded`, so a late timer retirement or journal
+failure from a Session that already left can never reach the slot's next
+occupant.
+
+Session end (PTY EOF/error, Kill followed by a final drain, or the child's
+exit observed by the reactor's process watch) detaches the fds on the
+reactor and runs the old epilogue on a `session-exit` thread: journal
+flushed and closed, timer jobs retired, **the child reaped**
+(`reap_hosted_child`: `try_wait`, then SIGTERM, a 1.5 s grace, SIGKILL, a
+bounded wait — signals only to a pid whose kernel start time matches the
+recorded one), the real exit code and exited manifest under the manifest
+lock, sockets removed, then the owner's `on_exit`. The core therefore never
+accumulates `<defunct>` children, however a Session ended. Every child is
+watched for exit at registration (`EVFILT_PROC` on macOS; no watch on
+Linux yet, where the exit shows as PTY EOF), so a shell that exits while a
+background job still holds the slave ends its Session instead of lingering
+with a zombie. The per-process `__session_host__` runs the same services
+with N = 1 and just blocks its main thread on that callback. After a
+teardown the reactor's next idle tick hands freed heap back to the OS
 (`malloc_zone_pressure_relief` / `malloc_trim`), so the core shrinks again
 after `unpeel rm`.
+
+Gates for the isolation and identity rules: `cargo test -p unpeel-core
+core_reactor` (bounded queue that never blocks, generation-checked timer
+and control messages with the slot held until the teardown reports, reaping
+of a live child, child exit observed without EOF) and the PTY case
+`pty_core_isolation` (a query-flooding terminal and a raw-mode child that
+never reads next to a healthy sibling whose socket must answer within its
+timeout; write-id dedup; kill and child-exit paths leaving no zombie and a
+real exit code).
 
 Measured 2026-09-02 (release, this Mac, `scripts/bench-memory.sh` with
 `UNPEEL_PTY_CORE=1`): per empty `sh` Session 0.42 MiB (0.56 before), per


### PR DESCRIPTION
Fixes the three shared-PTY-core defects from tonight's 0.5.1 incident and the server audit (F3, F7, and the `<defunct>` children). Design notes are in `docs/agents/pty-core.md` ("Per-session input isolation", "Slot identity", session end).

## 1. Blocking writes stalled siblings (audit F3, reproduced)

**Mechanism.** `process_pty_bytes` answered terminal queries (DA1/CPR/OSC colour) with `PtyWriter::write_all` on the reactor thread, and `PtyWriter::write` polled `POLLOUT` forever. A one-shot `Write` command also held `HostRuntime`'s lock across that same blocking write while the reactor took that lock in `drain_pending_input`. One terminal that stopped reading parked the reactor and every sibling's `session.sock` (the core's own `ping` runs on another thread, so it stayed healthy).

**Fix.** The reactor is the only PTY writer and only ever writes non-blockingly into a per-Session bounded (1 MiB) queue:
- query answers, `StreamInput` frames, and `Write` commands all go through `SessionIo::queue_pty_input` / `drain_pending_input` (`crates/unpeel-core/src/session_io.rs`), which writes the master fd directly and never takes `HostRuntime`'s lock;
- `Write` commands submit to the reactor (`Control::Input`, `ReactorHandle::submit_input`, `crates/unpeel-core/src/core_reactor.rs`) and are acked once queued; the write-id ledger moves onto the reactor-owned `SessionIo` so check → queue → record is one thread's sequence;
- a wedged terminal's writers are refused with `terminal is not accepting input (N bytes still queued)`; nothing already queued is lost;
- the in-place agent relaunch keeps its direct `PtyWriter`, now bounded at 5 s; input queued during a relaunch is deferred (`try_lock` on `agent_restart_lock`, no writable interest) and drained on the relaunch's wake or the idle tick.

## 2. Slot-reuse cross-talk (audit F7)

**Mechanism.** `Reactor::end_session` pushed the slot back onto `free_slots` synchronously while the teardown thread later sent `TimerMsg::Remove { slot }` and the journal writer `JournalDrained(slot)` / `JournalFailed(slot)`; `JournalFailed` ends whatever is in the slot.

**Fix.** Every cross-thread message carries a `SlotRef { slot, generation }` and is dropped when the generation is not the slot's current one (`with_session_ref`, `slot_is_current`; the timer keeps a generation per slot and always acks a `Remove`), and a slot returns to `free_slots` only when the teardown thread reports `Control::SessionEnded(slot_ref)` (`release_slot`).

## 3. Children never reaped

**Mechanism.** `SessionTeardown::run` did one non-blocking `try_wait`, wrote `exit_code: None`, then dropping the runtime closed the master (SIGHUP) and nobody waited.

**Fix.** `reap_hosted_child` (`session_io.rs`) runs in the teardown: `try_wait` → SIGTERM → 1.5 s grace → SIGKILL → bounded wait, signalling only a pid whose kernel start time matches the recorded one (identity `Unknown` falls back to the child handle's own `kill`), and the manifest carries the real exit code. `Reactor::register` now arms a process-exit watch for every hosted child (previously only `adopt`), so on macOS a shell that exits while a background job still holds the slave ends its Session instead of lingering with a zombie (Linux has no watch yet; exit shows as PTY EOF, as before).

## Tests

- `cargo test -p unpeel-core core_reactor`: real reactor + real PTYs — bounded queue that never blocks and dedups write ids; generation-gated timer and control messages with the slot held until the teardown reports (register N, end, register N into the freed slots, replay every late message); reaping a live child; child exit observed without PTY EOF.
- New PTY matrix case `pty_core_isolation`: a query-flooding raw-mode child and a raw-mode child that never reads next to a healthy sibling whose control socket must answer within 0.7 s; a `write` into the stuck terminal is refused promptly; write ids deduplicated; `kill` and (macOS) child-exit-without-EOF paths leave no zombie and record a real exit code.

## Left out on purpose

The takeover write-id dedup carry and pending-input re-arm (audit F4/F5) belong to the `takeover-coherence` lane, which rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
