### PR TITLE
fix: reduce terminal rendering and idle Host overhead

### DIFF
--- a/clients/ios/UnpeelIOS/Sources/UnpeelIOS/RemoteMacClient.swift
+++ b/clients/ios/UnpeelIOS/Sources/UnpeelIOS/RemoteMacClient.swift
@@ -230,6 +230,8 @@ public struct RemoteMacClient: Sendable {
         // fits; the host caps its read at `limit`, and offset polling catches
         // up over multiple chunks with no data loss.
         let effectiveLimit = isRelay ? min(limit, 200 * 1024) : limit
+        // Keep legacy safe-boundary replies. feedPrepared injects DEC 2026
+        // between pages, so it must not opt in to session.output.raw.
         var query = [
             "session_id": sessionID,
             "limit": "\(effectiveLimit)",

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/GhosttyBridge.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/GhosttyBridge.swift
@@ -624,8 +624,8 @@ final class GhosttyTerminalPane: NSView {
     /// in an occluded/minimized window must not keep Ghostty's renderer
     /// drawing frames nobody sees. The wrapper exposes this as
     /// `TerminalView.setSurfaceVisible(_:)` → `ghostty_surface_set_occlusion`
-    /// plus suspension of its wakeup→tick→draw loop, mirroring what Ghostty
-    /// itself does on `NSWindow.occlusionState` changes.
+    /// plus cancellation of scheduled refreshes. App-mailbox draining stays
+    /// wakeup-driven regardless of presentation visibility.
     private var occlusionObserver: NSObjectProtocol?
     var onPresentationVisibilityChanged: (() -> Void)?
     private var lastThemeSamplingVisibility = false
@@ -633,13 +633,8 @@ final class GhosttyTerminalPane: NSView {
         window?.occlusionState.contains(.visible) == true && !isHiddenOrHasHiddenAncestor
     }
 
-    // NOTE for pre-warmed panes (WarmPaneHostView): they are mounted inside
-    // a HIDDEN container but must NOT be paused via setSurfaceVisible(false)
-    // — that suspends the wrapper's wakeup→tick loop, and a surface that
-    // never ticks while its attach client floods the replay wedges its IO;
-    // the next synchronous surface call from the main thread (adoption on
-    // click) then deadlocks. Hidden-but-ticking is the safe state; the
-    // hidden container already keeps them out of the compositor.
+    // Warm panes remain occluded while their app mailboxes keep draining.
+    // Suppressing those ticks would let replay block IO and deadlock adoption.
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if let observer = occlusionObserver {
@@ -666,7 +661,7 @@ final class GhosttyTerminalPane: NSView {
             lastThemeSamplingVisibility = presented
             onPresentationVisibilityChanged?()
         }
-        let visible = window.map { $0.occlusionState.contains(.visible) } ?? false
+        let visible = presented
         terminalView.setSurfaceVisible(visible)
         if visible {
             // Resume with a fresh frame so the viewport is current: the
@@ -688,6 +683,16 @@ final class GhosttyTerminalPane: NSView {
     /// an image-streaming app-mode session visibly froze between forced
     /// draws while its io thread happily consumed megabytes.
     func refreshSurfaceVisibility() {
+        updateSurfaceVisibility()
+    }
+
+    override func viewDidHide() {
+        super.viewDidHide()
+        updateSurfaceVisibility()
+    }
+
+    override func viewDidUnhide() {
+        super.viewDidUnhide()
         updateSurfaceVisibility()
     }
 
@@ -1948,15 +1953,15 @@ struct RemoteTerminalLocalFeed: Equatable, Sendable {
             + endSynchronizedOutput
     )
 
-    /// Atomic reset + replacement output. RIS must precede DEC 2026 because
-    /// RIS itself resets synchronized-output mode.
+    /// Reset then feed in one delivery. End our bracket before Host bytes:
+    /// a raw page can end inside UTF-8 or a VT string, even after a reset.
     static func resettingBeforeFeeding(_ payload: Data) -> RemoteTerminalLocalFeed {
         RemoteTerminalLocalFeed(
             bytes: reset
                 + beginSynchronizedOutput
                 + clearDisplayAndScrollback
-                + payload
                 + endSynchronizedOutput
+                + payload
         )
     }
 }

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/RemoteHostRuntime.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/RemoteHostRuntime.swift
@@ -2523,6 +2523,14 @@ final class RemoteHostRuntime: ObservableObject {
             guard outputPumpIsCurrent(identity, connection: connection) else {
                 return
             }
+            // Older Hosts may return immediately with an incomplete UTF-8 or
+            // control-string suffix and an unchanged cursor. Commit the page
+            // normally, then bound retries instead of spinning on success.
+            if page.bytes.isEmpty,
+               page.metadata.requestedOffset == page.metadata.nextOffset,
+               !(await sleepOutputIdle()) {
+                return
+            }
         }
     }
 

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/UnpeelStore.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/UnpeelStore.swift
@@ -1632,6 +1632,15 @@ final class UnpeelStore: ObservableObject {
     /// twin above.
     private var scopeSessionMemory: [String: String] = [:]
 
+    /// A seed or connecting Local client is not Host truth yet. Forgetting the
+    /// remembered Local selection against that incomplete view is how a Session
+    /// created after launch vanished from the pane on workspace return.
+    private var localHostTruthIsComplete: Bool {
+        guard localHostProjectionReady else { return false }
+        if case .connected = remoteHostRuntime.connectionState { return true }
+        return false
+    }
+
     /// The remembered last selection for a scope — the swipe preview uses
     /// this so the pooled page highlights the row the committed scope will
     /// restore, instead of flashing the Host's default (top) row.
@@ -2219,11 +2228,10 @@ final class UnpeelStore: ObservableObject {
         // check Host truth, not the launch-frozen Swift scan, or a Session
         // created since launch would lose its selection on every return.
         connectLocalHostServiceIfNeeded()
-        if let prior = localSelectedSessionIDBeforeRemote,
-           displaySessionsByID[prior] != nil {
-            selectedSessionID = prior
-        }
-        localSelectedSessionIDBeforeRemote = nil
+        applyRememberedLocalSelection(
+            knownIDs: localHostProjectionReady ? Set(displaySessionsByID.keys) : [],
+            hostTruthIsComplete: localHostTruthIsComplete
+        )
         refreshTitlebarBranch()
         applyScopeTint()
         refreshScopeAppearance()
@@ -15271,6 +15279,50 @@ extension UnpeelStore {
         scope != .local || (localClientStarted && localProjectionReady)
     }
 
+    /// What to do with the Session that was selected when this window left Local.
+    enum RememberedScopeSelection: Equatable {
+        case select(String)
+        case keepRemembered
+        case forget
+    }
+
+    /// Host truth only. An incomplete projection (no Host snapshot yet, or a
+    /// seed that has not connected) must keep the remembered id: consulting the
+    /// launch-frozen disk scan, then discarding memory, is how a Session
+    /// created after launch returned to "No session selected".
+    nonisolated static func resolveRememberedSelection(
+        rememberedID: String?,
+        knownIDs: Set<String>,
+        hostTruthIsComplete: Bool
+    ) -> RememberedScopeSelection {
+        guard let rememberedID else { return .forget }
+        if knownIDs.contains(rememberedID) { return .select(rememberedID) }
+        if hostTruthIsComplete { return .forget }
+        return .keepRemembered
+    }
+
+    /// Re-select the Session that was open before this window left Local.
+    private func applyRememberedLocalSelection(
+        knownIDs: Set<String>,
+        hostTruthIsComplete: Bool
+    ) {
+        switch Self.resolveRememberedSelection(
+            rememberedID: localSelectedSessionIDBeforeRemote,
+            knownIDs: knownIDs,
+            hostTruthIsComplete: hostTruthIsComplete
+        ) {
+        case .select(let id):
+            localSelectedSessionIDBeforeRemote = nil
+            if selectedSessionID != id {
+                selectedSessionID = id
+            }
+        case .keepRemembered:
+            break
+        case .forget:
+            localSelectedSessionIDBeforeRemote = nil
+        }
+    }
+
     /// Once the Local Host client starts, semantic effects fail closed to its
     /// workspace worker even while startup/recovery is still showing the disk
     /// fallback. A missing socket must never silently reactivate the duplicate
@@ -15910,8 +15962,13 @@ extension UnpeelStore {
             if let selectedSessionID,
                projectedSessions[selectedSessionID] == nil {
                 self.selectedSessionID = nil
-            } else if !remoteHostRuntime.directDataPlaneSelectionIntentPending,
-                      remoteHostRuntime.selectedSessionID != selectedSessionID {
+            }
+            applyRememberedLocalSelection(
+                knownIDs: Set(projectedSessions.keys),
+                hostTruthIsComplete: localHostTruthIsComplete
+            )
+            if !remoteHostRuntime.directDataPlaneSelectionIntentPending,
+               remoteHostRuntime.selectedSessionID != selectedSessionID {
                 remoteHostRuntime.selectDirectDataPlaneSession(selectedSessionID)
             }
         }

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/Views/Chrome.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/Views/Chrome.swift
@@ -71,15 +71,8 @@ struct FrameBackdrop: View {
     var body: some View {
         ZStack {
             // Translucent paths stack their wash over a native glass base.
-            // .hudWindow is the clearest standard material, so low opacities
-            // read as glass rather than a gray slab. WITHIN-window blending,
-            // never behind-window: a behind-window blur is re-sampled from
-            // the desktop by WindowServer on the GPU every time anything in
-            // the window changes, and a TUI redrawing at 60 fps (OpenCode's
-            // progress UI) turned that into 80-90% whole-GPU utilization on
-            // a Retina/ProMotion display (unpeel#9). Within-window frosts
-            // only the window's own content, which costs nothing while the
-            // terminal repaints.
+            // The glass base requests .hudWindow material with within-window
+            // blending; the selected tone and opacity supply the color wash.
             if !transparency.backgroundUsesDesignTone {
                 // Custom tone: flat color (dark appearance; light keeps its
                 // designed white) plus the workspace wash every area shares.

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/Views/RootView.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/Views/RootView.swift
@@ -1054,15 +1054,21 @@ private struct TitlebarActivityMenuRow: View {
 /// frames with a lightweight TimelineView for the single titlebar affordance.
 private struct TitlebarBrailleSpinner: View {
     let color: Color
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var motionAllowed = false
+    @State private var isPresented = false
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: Theme.spinnerInterval)) { context in
-            Text(frame(for: context.date))
+        TimelineView(.animation(minimumInterval: Theme.spinnerInterval, paused: !isPresented || !motionAllowed || reduceMotion)) { context in
+            Text(reduceMotion ? Theme.spinnerFrames[0] : frame(for: context.date))
                 .font(.system(size: 14.7, weight: .bold, design: .monospaced))
                 .foregroundStyle(color)
                 .shadow(color: color.opacity(0.45), radius: 3)
                 .frame(width: 16, height: 16)
         }
+        .background(DecorationMotionReader(allowed: $motionAllowed))
+        .onAppear { isPresented = true }
+        .onDisappear { isPresented = false }
         .accessibilityHidden(true)
     }
 

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/Views/SidebarSpinners.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/Views/SidebarSpinners.swift
@@ -11,6 +11,98 @@ import AppKit
 import SwiftUI
 import UnpeelShared
 
+/// Shared presentation gate for decorative layers and SwiftUI timelines.
+class DecorationLifecycleView: NSView {
+    private(set) var motionAllowed = false
+    private let workspaceNotifications = NSWorkspace.shared.notificationCenter
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowVisibilityChanged(_:)),
+            name: NSWindow.didChangeOcclusionStateNotification, object: nil
+        )
+        workspaceNotifications.addObserver(
+            self, selector: #selector(motionPreferenceChanged),
+            name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification, object: nil
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        workspaceNotifications.removeObserver(self)
+    }
+
+    @objc private func windowVisibilityChanged(_ notification: Notification) {
+        guard let changedWindow = notification.object as? NSWindow,
+              changedWindow === window else { return }
+        updateMotionEligibility()
+    }
+
+    @objc private func motionPreferenceChanged() { updateMotionEligibility() }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        updateMotionEligibility()
+    }
+
+    override func viewDidHide() {
+        super.viewDidHide()
+        updateMotionEligibility()
+    }
+
+    override func viewDidUnhide() {
+        super.viewDidUnhide()
+        updateMotionEligibility()
+    }
+
+    override func layout() {
+        super.layout()
+        updateMotionEligibility()
+    }
+
+    static func allowsMotion(attached: Bool, visible: Bool, hidden: Bool, reduceMotion: Bool) -> Bool {
+        attached && visible && !hidden && !reduceMotion
+    }
+
+    private func updateMotionEligibility() {
+        let allowed = Self.allowsMotion(
+            attached: window != nil,
+            visible: window?.occlusionState.contains(.visible) == true,
+            hidden: isHiddenOrHasHiddenAncestor,
+            reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        )
+        guard allowed != motionAllowed else { return }
+        motionAllowed = allowed
+        motionEligibilityChanged()
+    }
+
+    func motionEligibilityChanged() {}
+}
+
+/// Observes the actual containing window, including Menu-label hosting.
+struct DecorationMotionReader: NSViewRepresentable {
+    @Binding var allowed: Bool
+
+    func makeNSView(context: Context) -> ReaderView {
+        let view = ReaderView(frame: .zero)
+        view.onChange = { value in
+            DispatchQueue.main.async { self.allowed = value }
+        }
+        return view
+    }
+
+    func updateNSView(_ view: ReaderView, context: Context) {}
+
+    final class ReaderView: DecorationLifecycleView {
+        var onChange: ((Bool) -> Void)?
+        override func motionEligibilityChanged() { onChange?(motionAllowed) }
+    }
+}
+
 
 /// Gradient sweep over a one-line label, replicating the Svelte
 /// `.project-name.shimmer` CSS:
@@ -69,9 +161,10 @@ struct ShimmerGradientView: NSViewRepresentable {
     }
 }
 
-final class ShimmerGradientLayerView: NSView {
+final class ShimmerGradientLayerView: DecorationLifecycleView {
     private var color: NSColor
     private let gradientLayer = CAGradientLayer()
+    private var animatedWidth: CGFloat?
 
     init(color: NSColor) {
         self.color = color
@@ -137,20 +230,23 @@ final class ShimmerGradientLayerView: NSView {
             width: bounds.width * 4, height: bounds.height
         )
         CATransaction.commit()
-        restartAnimation()
+        updateAnimation()
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window != nil {
-            needsLayout = true
-        } else {
-            gradientLayer.removeAnimation(forKey: "shimmer")
-        }
+        needsLayout = true
     }
 
-    private func restartAnimation() {
-        guard window != nil, bounds.width > 0 else { return }
+    override func motionEligibilityChanged() { updateAnimation() }
+
+    private func updateAnimation() {
+        guard motionAllowed, bounds.width > 0, bounds.height > 0 else {
+            gradientLayer.removeAnimation(forKey: "shimmer")
+            animatedWidth = nil
+            return
+        }
+        guard animatedWidth != bounds.width || gradientLayer.animation(forKey: "shimmer") == nil else { return }
         // background-position 100% → -100% over 1.8s linear infinite:
         // with a 2w gradient anchored at x = -w, that is a translation
         // from 0 to +2w.
@@ -162,6 +258,7 @@ final class ShimmerGradientLayerView: NSView {
         animation.repeatCount = .infinity
         gradientLayer.removeAnimation(forKey: "shimmer")
         gradientLayer.add(animation, forKey: "shimmer")
+        animatedWidth = bounds.width
     }
 }
 
@@ -198,7 +295,7 @@ private struct SpinnerLayerRepresentable: NSViewRepresentable {
     }
 }
 
-final class SpinnerLayerView: NSView {
+final class SpinnerLayerView: DecorationLifecycleView {
     private var color: NSColor
 
     init(color: NSColor) {
@@ -213,29 +310,29 @@ final class SpinnerLayerView: NSView {
     func setColor(_ color: NSColor) {
         guard !self.color.isEqual(color) else { return }
         self.color = color
-        if window != nil { restartAnimation() }
+        refreshFrames()
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window != nil {
-            restartAnimation()
-        } else {
-            layer?.removeAnimation(forKey: "spinner")
-        }
+        refreshFrames()
     }
 
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
-        if window != nil { restartAnimation() }
+        refreshFrames()
     }
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        if window != nil { restartAnimation() }
+        refreshFrames()
     }
 
-    private func restartAnimation() {
+    private var renderedFrames: [CGImage] = []
+
+    override func motionEligibilityChanged() { updateAnimation() }
+
+    private func refreshFrames() {
         guard let layer else { return }
         let scale = window?.backingScaleFactor ?? 2
         // Theme colors are appearance-dynamic; flatten against the view's
@@ -249,10 +346,22 @@ final class SpinnerLayerView: NSView {
         layer.contentsScale = scale
         // Static contents so non-animated renders (snapshots) show a frame.
         layer.contents = frames[0]
+        renderedFrames = frames
+        layer.removeAnimation(forKey: "spinner")
+        updateAnimation()
+    }
+
+    private func updateAnimation() {
+        guard let layer else { return }
+        guard motionAllowed, !renderedFrames.isEmpty else {
+            layer.removeAnimation(forKey: "spinner")
+            return
+        }
+        guard layer.animation(forKey: "spinner") == nil else { return }
         let animation = CAKeyframeAnimation(keyPath: "contents")
-        animation.values = frames
+        animation.values = renderedFrames
         animation.calculationMode = .discrete
-        animation.duration = Theme.spinnerInterval * Double(frames.count)
+        animation.duration = Theme.spinnerInterval * Double(renderedFrames.count)
         animation.repeatCount = .infinity
         layer.removeAnimation(forKey: "spinner")
         layer.add(animation, forKey: "spinner")

--- a/clients/native/UnpeelNative/Sources/UnpeelNative/Views/TerminalArea.swift
+++ b/clients/native/UnpeelNative/Sources/UnpeelNative/Views/TerminalArea.swift
@@ -1213,6 +1213,8 @@ struct PixelMascotView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var frameIndex = 0
+    @State private var playbackStarted = false
+    @State private var motionAllowed = false
 
     /// The webp's frame cadence: 4 frames × 200ms.
     private static let frameDuration: TimeInterval = 0.2
@@ -1236,25 +1238,31 @@ struct PixelMascotView: View {
                     .interpolation(.none)
                     .resizable()
                     .scaledToFit()
-                    .task { await playLoop(frameCount: frames.count) }
+                    .task(id: motionAllowed && !reduceMotion) {
+                        await playOnce(frameCount: frames.count)
+                    }
             } else {
                 AppBrandLogo()
                     .foregroundStyle(Theme.mutedForeground)
             }
         }
         .frame(width: size, height: size)
+        .background(DecorationMotionReader(allowed: $motionAllowed))
         .accessibilityHidden(true)
     }
 
-    /// Loop the frames at the webp's cadence (like the phone). Cancels
-    /// cleanly with the view via `.task`; static under Reduce Motion.
-    private func playLoop(frameCount: Int) async {
-        guard !reduceMotion else { return }
+    /// A finite greeting. Hiding or enabling Reduce Motion cancels playback
+    /// and returns to rest rather than restarting the greeting on reveal.
+    private func playOnce(frameCount: Int) async {
+        frameIndex = 0
+        guard !reduceMotion, motionAllowed, !playbackStarted else { return }
+        playbackStarted = true
         let step = UInt64(Self.frameDuration * 1_000_000_000)
-        while !Task.isCancelled {
-            try? await Task.sleep(nanoseconds: step)
+        for index in 1...frameCount {
+            do { try await Task.sleep(nanoseconds: step) }
+            catch { return }
             guard !Task.isCancelled else { return }
-            frameIndex = (frameIndex + 1) % frameCount
+            frameIndex = index % frameCount
         }
     }
 }

--- a/clients/native/UnpeelNative/Tests/UnpeelNativeTests/DecorationLifecycleTests.swift
+++ b/clients/native/UnpeelNative/Tests/UnpeelNativeTests/DecorationLifecycleTests.swift
@@ -67,7 +67,7 @@ final class DecorationLifecycleTests: XCTestCase {
         shimmer.frame = NSRect(x: 0, y: 0, width: 100, height: 16)
         shimmer.layout()
         let gradient = try XCTUnwrap(shimmer.layer?.sublayers?.first)
-        let original = try XCTUnwrap(gradient.animation(forKey: "shimmer"))
+        let original = try XCTUnwrap(gradient.animation(forKey: "shimmer")?.copy() as? CAAnimation)
         original.beginTime = 123
         gradient.add(original, forKey: "shimmer")
         shimmer.layout()

--- a/clients/native/UnpeelNative/Tests/UnpeelNativeTests/DecorationLifecycleTests.swift
+++ b/clients/native/UnpeelNative/Tests/UnpeelNativeTests/DecorationLifecycleTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import XCTest
+@testable import UnpeelNative
+
+@MainActor
+final class DecorationLifecycleTests: XCTestCase {
+    private final class PresentationWindow: NSWindow {
+        var presented = true
+        override var occlusionState: NSWindow.OcclusionState {
+            presented ? [.visible] : []
+        }
+
+        func setPresented(_ value: Bool) {
+            presented = value
+            NotificationCenter.default.post(name: NSWindow.didChangeOcclusionStateNotification, object: self)
+        }
+    }
+
+    func testMotionRequiresVisibleAttachedViewWithoutReducedMotion() {
+        for attached in [false, true] {
+            for visible in [false, true] {
+                for hidden in [false, true] {
+                    for reduced in [false, true] {
+                        XCTAssertEqual(
+                            DecorationLifecycleView.allowsMotion(
+                                attached: attached, visible: visible, hidden: hidden, reduceMotion: reduced
+                            ),
+                            attached && visible && !hidden && !reduced
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    func testShimmerStopsForOcclusionHiddenAncestorAndDetach() throws {
+        try requireMotion()
+        let window = makeWindow()
+        let parent = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 30))
+        window.contentView = parent
+        let shimmer = ShimmerGradientLayerView(color: .white)
+        shimmer.frame = parent.bounds
+        parent.addSubview(shimmer)
+        shimmer.layout()
+        let gradient = try XCTUnwrap(shimmer.layer?.sublayers?.first)
+        XCTAssertNotNil(gradient.animation(forKey: "shimmer"))
+
+        window.setPresented(false)
+        XCTAssertNil(gradient.animation(forKey: "shimmer"))
+        window.setPresented(true)
+        XCTAssertNotNil(gradient.animation(forKey: "shimmer"))
+
+        parent.isHidden = true
+        XCTAssertNil(gradient.animation(forKey: "shimmer"))
+        parent.isHidden = false
+        XCTAssertNotNil(gradient.animation(forKey: "shimmer"))
+
+        shimmer.removeFromSuperview()
+        XCTAssertNil(gradient.animation(forKey: "shimmer"))
+    }
+
+    func testUnchangedShimmerLayoutKeepsAnimationButResizeUpdatesTravel() throws {
+        try requireMotion()
+        let window = makeWindow()
+        let shimmer = ShimmerGradientLayerView(color: .white)
+        window.contentView?.addSubview(shimmer)
+        shimmer.frame = NSRect(x: 0, y: 0, width: 100, height: 16)
+        shimmer.layout()
+        let gradient = try XCTUnwrap(shimmer.layer?.sublayers?.first)
+        let original = try XCTUnwrap(gradient.animation(forKey: "shimmer"))
+        original.beginTime = 123
+        gradient.add(original, forKey: "shimmer")
+        shimmer.layout()
+        XCTAssertEqual(gradient.animation(forKey: "shimmer")?.beginTime, 123)
+
+        shimmer.frame.size.width = 150
+        shimmer.layout()
+        let resized = try XCTUnwrap(gradient.animation(forKey: "shimmer") as? CABasicAnimation)
+        XCTAssertEqual(resized.toValue as? CGFloat, 300)
+    }
+
+    func testSpinnerRetainsStaticFrameWhileOccludedAndStopsOnDetach() throws {
+        try requireMotion()
+        let window = makeWindow()
+        let spinner = SpinnerLayerView(color: .white)
+        window.contentView?.addSubview(spinner)
+        let layer = try XCTUnwrap(spinner.layer)
+        XCTAssertNotNil(layer.animation(forKey: "spinner"))
+        window.setPresented(false)
+        XCTAssertNil(layer.animation(forKey: "spinner"))
+        XCTAssertNotNil(layer.contents)
+        window.setPresented(true)
+        XCTAssertNotNil(layer.animation(forKey: "spinner"))
+        spinner.isHidden = true
+        XCTAssertNil(layer.animation(forKey: "spinner"))
+        spinner.isHidden = false
+        XCTAssertNotNil(layer.animation(forKey: "spinner"))
+        spinner.removeFromSuperview()
+        XCTAssertNil(layer.animation(forKey: "spinner"))
+    }
+
+    private func requireMotion() throws {
+        _ = NSApplication.shared
+        try XCTSkipIf(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+                      "Layer playback checks require Reduce Motion off; policy coverage tests both preferences.")
+    }
+
+    private func makeWindow() -> PresentationWindow {
+        let window = PresentationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 40),
+            styleMask: [.borderless], backing: .buffered, defer: false
+        )
+        window.isReleasedWhenClosed = false
+        return window
+    }
+}

--- a/clients/native/UnpeelNative/Tests/UnpeelNativeTests/LocalHostClientFeatureTests.swift
+++ b/clients/native/UnpeelNative/Tests/UnpeelNativeTests/LocalHostClientFeatureTests.swift
@@ -155,4 +155,40 @@ final class LocalHostClientFeatureTests: XCTestCase {
             localHostProjectionReady: true
         ))
     }
+
+    func testReturningToLocalKeepsARememberedSessionUntilHostTruthIsReady() {
+        let createdAfterLaunch = "bdbbc5b7-051f-42a1-8504-41f7a058570d"
+        XCTAssertEqual(
+            UnpeelStore.resolveRememberedSelection(
+                rememberedID: createdAfterLaunch,
+                knownIDs: [],
+                hostTruthIsComplete: false
+            ),
+            .keepRemembered
+        )
+        XCTAssertEqual(
+            UnpeelStore.resolveRememberedSelection(
+                rememberedID: createdAfterLaunch,
+                knownIDs: [createdAfterLaunch],
+                hostTruthIsComplete: false
+            ),
+            .select(createdAfterLaunch)
+        )
+        XCTAssertEqual(
+            UnpeelStore.resolveRememberedSelection(
+                rememberedID: createdAfterLaunch,
+                knownIDs: ["other"],
+                hostTruthIsComplete: true
+            ),
+            .forget
+        )
+        XCTAssertEqual(
+            UnpeelStore.resolveRememberedSelection(
+                rememberedID: nil,
+                knownIDs: [createdAfterLaunch],
+                hostTruthIsComplete: true
+            ),
+            .forget
+        )
+    }
 }

--- a/clients/native/UnpeelNative/Tests/UnpeelNativeTests/RemoteGhosttyPaneRetentionTests.swift
+++ b/clients/native/UnpeelNative/Tests/UnpeelNativeTests/RemoteGhosttyPaneRetentionTests.swift
@@ -105,8 +105,18 @@ final class RemoteGhosttyPaneRetentionTests: XCTestCase {
         )
         XCTAssertEqual(
             RemoteTerminalLocalFeed.resettingBeforeFeeding(payload).bytes,
-            reset + begin + clear + payload + end
+            reset + begin + clear + end + payload
         )
+    }
+
+    func testResetFeedPreservesRawContinuationInsideScalarAndControlStrings() {
+        for journal in [Data("€".utf8), Data("\u{1B}]0;title\u{7}".utf8), Data("\u{1B}_payload\u{1B}\\".utf8)] {
+            for split in 1..<journal.count {
+                let first = RemoteTerminalLocalFeed.resettingBeforeFeeding(Data(journal.prefix(split))).bytes
+                let feed = first + journal.dropFirst(split)
+                XCTAssertEqual(feed, RemoteTerminalLocalFeed.resetRetainedState.bytes + journal)
+            }
+        }
     }
 
     func testSessionIdentityIsScopedByHost() {

--- a/clients/native/UnpeelNative/Tests/UnpeelNativeTests/RemoteHostRuntimeTests.swift
+++ b/clients/native/UnpeelNative/Tests/UnpeelNativeTests/RemoteHostRuntimeTests.swift
@@ -2501,6 +2501,33 @@ final class RemoteHostRuntimeTests: XCTestCase {
         runtime.disconnect()
     }
 
+    func testEmptySuccessfulOutputIsCommittedThenPacedAndCancellationStopsRetry() async {
+        let backend = ControlledRemoteBackend()
+        let runtime = makeRuntime(
+            outputIdleIntervalNanoseconds: 200_000_000,
+            backendFactory: { _ in backend }
+        )
+        await connectWithSelectedSession(runtime, backend: backend)
+        XCTAssertNotNil(runtime.terminalPane(for: "session"))
+        await waitUntil { await backend.pollCount == 1 }
+        await backend.resolvePoll(.success(makePage(sessionID: "session", bytes: Data())))
+        await waitUntil { await backend.committedPageCount == 1 }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let pacedCount = await backend.pollCount
+        XCTAssertEqual(pacedCount, 1)
+        await waitUntil(iterations: 5_000) { await backend.pollCount == 2 }
+
+        // Real output should immediately continue draining, without idle pacing.
+        await backend.resolvePoll(.success(makePage(sessionID: "session", bytes: Data("x".utf8))))
+        await waitUntil { await backend.pollCount == 3 }
+        await backend.resolvePoll(.success(makePage(sessionID: "session", bytes: Data())))
+        await waitUntil { await backend.committedPageCount == 3 }
+        runtime.disconnect()
+        try? await Task.sleep(nanoseconds: 220_000_000)
+        let stoppedCount = await backend.pollCount
+        XCTAssertEqual(stoppedCount, 3)
+    }
+
     func testUTF8ScalarSplitAcrossCallbacksStartsFreshBoundedBatch() async {
         let backend = ControlledRemoteBackend(controlWrites: true)
         let runtime = makeRuntime(backend: backend)
@@ -2897,6 +2924,7 @@ final class RemoteHostRuntimeTests: XCTestCase {
 
     private func makeRuntime(
         refreshIntervalNanoseconds: UInt64 = 60_000_000_000,
+        outputIdleIntervalNanoseconds: UInt64 = 1_000_000,
         initialBootstrapRetryIntervalNanoseconds: UInt64 = 1_000_000,
         initialBootstrapFastRetryCount: Int = 3,
         initialDirectLinkGraceNanoseconds: UInt64 = 60_000_000_000,
@@ -2917,7 +2945,7 @@ final class RemoteHostRuntimeTests: XCTestCase {
             initialDirectLinkGraceNanoseconds: initialDirectLinkGraceNanoseconds,
             directProbeSuccessfulLinkRefreshes: directProbeSuccessfulLinkRefreshes,
             forceLinkForDevelopment: forceLinkForDevelopment,
-            outputIdleIntervalNanoseconds: 1_000_000,
+            outputIdleIntervalNanoseconds: outputIdleIntervalNanoseconds,
             resizeDebounceNanoseconds: 1_000_000,
             fitSettleNanoseconds: 0,
             fitClearDelayNanoseconds: 0,

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController.swift
@@ -59,7 +59,6 @@ public final class TerminalController {
 
     public internal(set) var lastConfigurationIssue: String?
     var onWakeup: (() -> Void)?
-    var shouldProcessWakeup: (() -> Bool)?
 
     // MARK: - Config Resolution State
 
@@ -290,11 +289,8 @@ public final class TerminalController {
     }
 
     func handleWakeup() {
-        guard shouldProcessWakeup?() ?? true else {
-            TerminalDebugLog.log(.lifecycle, "wakeup suspended")
-            return
-        }
-
+        // The mailbox carries lifecycle and IO callbacks even for hidden or
+        // detached retained surfaces. Only rendering may depend on visibility.
         tick()
         onWakeup?()
     }

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/InMemory/InMemoryTerminalSession.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/InMemory/InMemoryTerminalSession.swift
@@ -66,7 +66,7 @@ public final class InMemoryTerminalSession: @unchecked Sendable {
         var notify: (@Sendable () -> Void)?
         if surface != nil {
             flushPendingReceiveBufferLocked()
-            // Arm the render pump for the attach itself: a freshly attached
+            // Request a refresh for the attach itself: a freshly attached
             // (or re-attached, e.g. cache remount) surface must present its
             // replayed content without waiting for the next byte.
             notify = hostBytesHandler
@@ -163,12 +163,12 @@ public final class InMemoryTerminalSession: @unchecked Sendable {
     // MARK: - Receiving Data
 
     /// Fired after host bytes are written into the surface. The surface
-    /// coordinator wires this to its render pump: the embedded core
+    /// coordinator wires this to its coalesced refresh scheduler: the embedded core
     /// coalesces render wakeups under IO load, so a purely host-fed surface
     /// (no PTY, no local input) can hold freshly parsed terminal state on a
-    /// stale frame — blank or partial regions until a resize forces a draw.
-    /// Arming the pump on every host write makes remote-fed output present
-    /// like local IO. Invoked outside the session lock.
+    /// stale frame with blank or partial regions until a resize forces a draw.
+    /// Every completed host write requests a refresh without an idle timer.
+    /// Invoked outside the session lock, including while rendering is hidden.
     var onHostBytes: (@Sendable () -> Void)? {
         get {
             lock.lock()

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Input.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Input.swift
@@ -339,12 +339,8 @@
                 y: event.scrollingDeltaY,
                 mods: scrollMods.rawValue
             )
-            // Open the render pump so repaints present at display rate from
-            // the first wheel event instead of waiting on coalesced wakeups.
-            // Covers both local scrollback moves inside the core and
-            // mouse-captured TUIs (Claude's virtual scroll) repainting via
-            // the PTY roundtrip — with no per-event main-thread tick, since
-            // the pump refreshes the renderer off-main.
+            // Coalesce wheel events into one refresh on main. Later PTY
+            // output drives the core renderer; no timed refresh tail runs.
             core.noteRenderActivity()
         }
 

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Lifecycle.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Lifecycle.swift
@@ -73,7 +73,7 @@
                 )
                 updateMetalLayerMetrics()
                 updateColorScheme()
-                core.startDisplayLink()
+                core.refreshPresentationVisibility()
                 core.requestImmediateTick()
 
                 NotificationCenter.default.addObserver(
@@ -103,10 +103,35 @@
                     name: NSWindow.didChangeScreenNotification,
                     object: window
                 )
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: #selector(windowDidChangeOcclusion),
+                    name: NSWindow.didChangeOcclusionStateNotification,
+                    object: window
+                )
             } else {
-                core.stopDisplayLink()
+                core.stopRendering()
                 core.setFocus(false)
             }
+        }
+
+        override open func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            core.refreshPresentationVisibility()
+        }
+
+        override open func viewDidHide() {
+            super.viewDidHide()
+            core.refreshPresentationVisibility()
+        }
+
+        override open func viewDidUnhide() {
+            super.viewDidUnhide()
+            core.refreshPresentationVisibility()
+        }
+
+        @objc func windowDidChangeOcclusion(_: Notification) {
+            core.refreshPresentationVisibility()
         }
 
         @objc func windowDidBecomeKey(_: Notification) {
@@ -156,6 +181,11 @@
             NotificationCenter.default.removeObserver(
                 self,
                 name: NSWindow.didChangeScreenNotification,
+                object: nil
+            )
+            NotificationCenter.default.removeObserver(
+                self,
+                name: NSWindow.didChangeOcclusionStateNotification,
                 object: nil
             )
         }

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView.swift
@@ -111,6 +111,11 @@
             setupTrackingArea()
 
             core.isAttached = { [weak self] in self?.window != nil }
+            core.isPresented = { [weak self] in
+                guard let self else { return false }
+                return !isHiddenOrHasHiddenAncestor
+                    && window?.occlusionState.contains(.visible) == true
+            }
             core.scaleFactor = { [weak self] in
                 // Detached views keep their LAST window's scale: falling
                 // back to NSScreen.main mid-reparent can flip a 2x surface

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/UIKit/UITerminalView+Lifecycle.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/UIKit/UITerminalView+Lifecycle.swift
@@ -64,7 +64,7 @@
                     core.rebuildIfReady()
                 }
                 updateColorScheme()
-                core.startDisplayLink()
+                core.refreshPresentationVisibility()
                 // Defer sublayer frame and metrics sync to the next runloop
                 // so that AutoLayout has resolved final bounds.
                 DispatchQueue.main.async { [weak self] in
@@ -78,7 +78,7 @@
                 }
             } else {
                 lastSynchronousLayoutPixelSize = .zero
-                core.stopDisplayLink()
+                core.stopRendering()
                 if retainsSurfaceWhenDetached {
                     TerminalDebugLog.log(.lifecycle, "surface retained while detached")
                 } else {

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalRenderScheduler.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalRenderScheduler.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// One refresh for the pending batch, with no idle timer or display-link
+/// subscription. Transport threads may request work; delivery is on main.
+/// Requests coalesce until the next main-queue turn, without a trailing timer.
+final class TerminalRenderScheduler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var enabled = true
+    private var pending: DispatchWorkItem?
+    private var generation: UInt64 = 0
+    private let enqueue: @Sendable (DispatchWorkItem) -> Void
+    private let render: @MainActor @Sendable () -> Void
+
+    init(
+        enqueue: @escaping @Sendable (DispatchWorkItem) -> Void = {
+            DispatchQueue.main.async(execute: $0)
+        },
+        render: @escaping @MainActor @Sendable () -> Void
+    ) {
+        self.enqueue = enqueue
+        self.render = render
+    }
+
+    func request() {
+        lock.lock()
+        guard enabled, pending == nil else {
+            lock.unlock()
+            return
+        }
+        generation &+= 1
+        let requestedGeneration = generation
+        let work = DispatchWorkItem { [weak self] in
+            self?.deliver(generation: requestedGeneration)
+        }
+        pending = work
+        lock.unlock()
+        enqueue(work)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        lock.lock()
+        self.enabled = enabled
+        if !enabled { cancelLocked() }
+        lock.unlock()
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelLocked()
+        lock.unlock()
+    }
+
+    private func cancelLocked() {
+        generation &+= 1
+        pending?.cancel()
+        pending = nil
+    }
+
+    private func deliver(generation requestedGeneration: UInt64) {
+        lock.lock()
+        guard enabled, generation == requestedGeneration, pending != nil else {
+            lock.unlock()
+            return
+        }
+        pending = nil
+        lock.unlock()
+        // The default queue and test drivers deliver on main. No raw Ghostty
+        // handle crosses threads, and teardown cancels before freeing it.
+        MainActor.assumeIsolated { render() }
+    }
+
+    deinit { pending?.cancel() }
+}

--- a/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceCoordinator.swift
+++ b/clients/native/vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceCoordinator.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import GhosttyKit
-import MSDisplayLink
 
 /// Shared terminal state and logic used by both UIKit and AppKit views.
 ///
@@ -40,6 +39,7 @@ final class TerminalSurfaceCoordinator {
     // MARK: - Platform Hooks
 
     var isAttached: () -> Bool = { false }
+    var isPresented: () -> Bool = { true }
     var scaleFactor: () -> Double = { 2.0 }
     var viewSize: () -> (width: Double, height: Double) = { (0, 0) }
     /// CGDirectDisplayID of the display hosting the view, for binding the
@@ -49,7 +49,7 @@ final class TerminalSurfaceCoordinator {
     var onMetricsUpdate: (() -> Void)?
     var onCellSizeDidChange: (() -> Void)?
 
-    /// Called after every display-link render (`tick`).
+    /// Called after every requested render.
     ///
     /// When `synchronizeMetrics` sends a new pixel size to ghostty via
     /// `setSize`, the underlying IOSurface is not rebuilt synchronously.
@@ -72,9 +72,9 @@ final class TerminalSurfaceCoordinator {
     private var isDisplayVisible = true
     private var isApplicationActive = true
     private var isSurfaceFocused = false
-    private var pendingImmediateTick = true
-    private var lastTickTimestamp: TimeInterval = 0
-    private var tickScheduled = false
+    private lazy var renderScheduler = TerminalRenderScheduler { [weak self] in
+        self?.renderImmediately()
+    }
 
     init() {
         bridge.onCellSizeChange = { [weak self] width, height in
@@ -83,46 +83,20 @@ final class TerminalSurfaceCoordinator {
         bridge.onRenderRequest = { [weak self] in
             self?.requestImmediateTick()
         }
-        activityLink.delegatingObject(activityRelay)
     }
 
     func requestImmediateTick() {
-        pendingImmediateTick = true
-        noteRenderActivity()
-        scheduleTickIfNeeded()
+        guard canRenderFrame else { return }
+        renderScheduler.request()
     }
 
-    // MARK: - Activity-window render pump
+    // MARK: - Event-driven refresh
 
-    /// Ghostty's embedded core coalesces wakeup callbacks and render
-    /// actions under IO load (aggressively so since the tip VT-throughput
-    /// work), so a purely push-driven embedder can sit on a stale frame:
-    /// TUI repaints (Claude's virtual scroll, jump-to-bottom redraws)
-    /// arrived but nothing told us to draw — the screen looked blank or
-    /// frozen until a resize forced a frame. While the activity window is
-    /// open, the display link nudges the core renderer thread every frame
-    /// (`ghostty_surface_refresh`), pulling whatever the core queued
-    /// instead of waiting to be pushed. The window re-arms on every render
-    /// request and on user scroll input, and the relay gate keeps
-    /// closed-window frames to one lock acquisition.
-    ///
-    /// The nudge runs directly on the display-link thread — never the main
-    /// thread. `refresh` is a renderer-mailbox push + async wakeup (the
-    /// same call termio makes cross-thread on PTY output), so frame
-    /// production stays at display rate even when the main thread is busy
-    /// with AppKit/SwiftUI work. App ticks (`ghostty_app_tick`) are not
-    /// part of the per-frame path; they stay wakeup-driven via
-    /// `scheduleTickIfNeeded`.
-    private let activityLink = DisplayLink()
-    private let activityRelay = TerminalActivityLinkRelay()
-    private nonisolated static let activityWindowDuration: TimeInterval = 1.0
-
-    /// Opens (or extends) the activity window. Also called by platform
-    /// views on scroll input so a mouse-captured TUI's repaints present at
-    /// display rate from the first wheel event.
+    /// Scroll input needs an explicit refresh even when the core coalesces
+    /// its render action. Later TUI output is rendered by the core; host-fed
+    /// output also requests a refresh after each completed write.
     func noteRenderActivity() {
-        guard canRenderFrame else { return }
-        activityRelay.arm(for: Self.activityWindowDuration)
+        requestImmediateTick()
     }
 
     /// Presents the current frame without blocking the main thread.
@@ -148,13 +122,15 @@ final class TerminalSurfaceCoordinator {
         onPostRender?()
     }
 
-    func startDisplayLink() {
-        scheduleTickIfNeeded()
+    func refreshPresentationVisibility() {
+        surface?.setOcclusion(effectiveSurfaceVisible)
+        renderScheduler.setEnabled(canRenderFrame)
+        requestImmediateTick()
     }
 
-    func stopDisplayLink() {
-        tickScheduled = false
-        activityRelay.disarm()
+    func stopRendering() {
+        surface?.setOcclusion(false)
+        renderScheduler.setEnabled(false)
     }
 
     // MARK: - Surface Lifecycle
@@ -205,27 +181,19 @@ final class TerminalSurfaceCoordinator {
 
         bridge.rawSurface = newSurface.rawValue
         surface = newSurface
-        activityRelay.setSurfaceHandle(newSurface.rawValue)
         newSurface.setOcclusion(effectiveSurfaceVisible)
         if let displayID = currentDisplayID() {
             newSurface.setDisplayID(displayID)
         }
-        controller.shouldProcessWakeup = { [weak self] in
-            self?.canRenderFrame == true
-        }
         controller.onWakeup = { [weak self] in
             self?.requestImmediateTick()
         }
-        // Host-fed (in-memory) surfaces have no PTY IO driving core render
-        // wakeups, and the core coalesces them aggressively under load —
-        // freshly written bytes could sit unparsed-on-screen (blank/stale
-        // regions) until a resize forced a frame. Arm the render pump on
-        // every host write so remote output presents at display rate. The
-        // relay is thread-safe, so the transport thread arms it directly —
-        // no main-thread hop between host bytes and the next frame.
-        let relay = activityRelay
+        // Writes finish parsing before this notification. Coalesce transport
+        // threads onto main without retaining or touching a raw surface.
+        renderScheduler.setEnabled(canRenderFrame)
+        let scheduler = renderScheduler
         configuration.inMemorySession?.onHostBytes = {
-            relay.arm(for: Self.activityWindowDuration)
+            scheduler.request()
         }
         TerminalDebugLog.log(.lifecycle, "surface rebuild succeeded")
         (delegate as? any TerminalSurfaceLifecycleDelegate)?
@@ -385,19 +353,8 @@ final class TerminalSurfaceCoordinator {
     }
 
     func setDisplayVisible(_ visible: Bool) {
-        guard isDisplayVisible != visible else {
-            surface?.setOcclusion(effectiveSurfaceVisible)
-            return
-        }
-
         isDisplayVisible = visible
-        surface?.setOcclusion(effectiveSurfaceVisible)
-
-        if canRenderFrame {
-            requestImmediateTick()
-        } else {
-            stopDisplayLink()
-        }
+        refreshPresentationVisibility()
     }
 
     func setApplicationActive(_ active: Bool) {
@@ -405,33 +362,21 @@ final class TerminalSurfaceCoordinator {
             if active {
                 renderImmediately()
             } else {
-                stopDisplayLink()
+                stopRendering()
             }
             return
         }
 
         isApplicationActive = active
         surface?.setOcclusion(effectiveSurfaceVisible)
+        renderScheduler.setEnabled(canRenderFrame)
 
         if active {
             synchronizeMetrics()
             renderImmediately()
         } else {
-            stopDisplayLink()
+            stopRendering()
         }
-    }
-
-    // MARK: - Frame Rendering
-
-    func tick(context: DisplayLinkCallbackContext) {
-        guard shouldRenderFrame(at: context.timestamp) else {
-            return
-        }
-        pendingImmediateTick = false
-        lastTickTimestamp = context.timestamp
-        TerminalDebugLog.log(.render, "tick")
-        controller?.tick()
-        presentFrame()
     }
 
     // MARK: - Focus
@@ -468,17 +413,12 @@ final class TerminalSurfaceCoordinator {
         asynchronously: Bool = false
     ) {
         TerminalDebugLog.log(.lifecycle, "tear down surface")
-        tickScheduled = false
-        // Blocks until any in-flight display-link refresh returns, and keeps
-        // later frames off this surface — must precede the free below.
-        activityRelay.setSurfaceHandle(nil)
-        activityRelay.disarm()
+        renderScheduler.setEnabled(false)
         if let session = configuration.inMemorySession {
             session.onHostBytes = nil
             session.clearSurface(ifMatches: surface?.rawValue)
         }
         controller?.onWakeup = nil
-        controller?.shouldProcessWakeup = nil
         bridge.rawSurface = nil
         let hadSurface = surface != nil
         surface?.setFocus(false)
@@ -492,8 +432,6 @@ final class TerminalSurfaceCoordinator {
         lastSentPixelSize = nil
         lastSentScale = nil
         pendingSynchronousDraw = false
-        pendingImmediateTick = true
-        lastTickTimestamp = 0
         controller?.remove(bridge)
         if hadSurface {
             (delegate as? any TerminalSurfaceLifecycleDelegate)?
@@ -511,47 +449,12 @@ final class TerminalSurfaceCoordinator {
         onCellSizeDidChange?()
     }
 
-    private func shouldRenderFrame(at _: TimeInterval) -> Bool {
-        guard canRenderFrame else {
-            return false
-        }
-        return pendingImmediateTick || lastTickTimestamp == 0
-    }
-
-    private func scheduleTickIfNeeded() {
-        guard canRenderFrame else {
-            tickScheduled = false
-            return
-        }
-        guard !tickScheduled else {
-            return
-        }
-        tickScheduled = true
-        TerminalDebugLog.log(.lifecycle, "tick scheduled")
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            tickScheduled = false
-            let timestamp = Self.monotonicTimestamp()
-            tick(
-                context: .init(
-                    duration: 0,
-                    timestamp: timestamp,
-                    targetTimestamp: timestamp
-                )
-            )
-        }
-    }
-
-    private static func monotonicTimestamp() -> TimeInterval {
-        ProcessInfo.processInfo.systemUptime
-    }
-
     private var effectiveSurfaceVisible: Bool {
-        isDisplayVisible && isApplicationActive
+        isDisplayVisible && isApplicationActive && isAttached() && isPresented()
     }
 
     private var canRenderFrame: Bool {
-        effectiveSurfaceVisible && isAttached()
+        effectiveSurfaceVisible
     }
 
     private var hasValidViewSize: Bool {
@@ -560,21 +463,9 @@ final class TerminalSurfaceCoordinator {
     }
 
     func renderImmediately() {
-        guard canRenderFrame else {
-            tickScheduled = false
-            return
-        }
-
-        pendingImmediateTick = true
-        tickScheduled = false
-        let timestamp = Self.monotonicTimestamp()
-        tick(
-            context: .init(
-                duration: 0,
-                timestamp: timestamp,
-                targetTimestamp: timestamp
-            )
-        )
+        renderScheduler.cancel()
+        guard canRenderFrame else { return }
+        presentFrame()
     }
 
     /// `renderImmediately`, but the frame draws synchronously even when the
@@ -589,54 +480,5 @@ final class TerminalSurfaceCoordinator {
             pendingSynchronousDraw = true
         }
         renderImmediately()
-    }
-}
-
-/// Nudges the core renderer thread at display cadence while the
-/// coordinator's activity window is open. `synchronization` fires on the
-/// display-link thread every frame for the lifetime of the link; the
-/// lock-guarded gate keeps closed-window frames to a single lock
-/// acquisition with no main-thread work.
-///
-/// The refresh call deliberately happens under the lock: the coordinator
-/// clears `surfaceHandle` (also under the lock) before the raw surface is
-/// freed, so an in-flight frame can never race the free — the clear blocks
-/// until the refresh returns, and refresh itself is a sub-microsecond
-/// mailbox push.
-final class TerminalActivityLinkRelay: DisplayLinkDelegate, @unchecked Sendable {
-    private let lock = NSLock()
-    private var deadline: TimeInterval = 0
-    private var surfaceHandle: ghostty_surface_t?
-
-    /// Opens (or extends) the activity window. Safe from any thread —
-    /// in-memory host feeds call this straight off their transport thread.
-    func arm(for duration: TimeInterval) {
-        let newDeadline = ProcessInfo.processInfo.systemUptime + duration
-        lock.lock()
-        deadline = max(deadline, newDeadline)
-        lock.unlock()
-    }
-
-    func disarm() {
-        lock.lock()
-        deadline = 0
-        lock.unlock()
-    }
-
-    /// Swap the raw surface the relay may refresh. Must be called with nil
-    /// before the previous surface is freed.
-    func setSurfaceHandle(_ handle: ghostty_surface_t?) {
-        lock.lock()
-        surfaceHandle = handle
-        lock.unlock()
-    }
-
-    func synchronization(context _: DisplayLinkCallbackContext) {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let handle = surfaceHandle,
-              ProcessInfo.processInfo.systemUptime <= deadline
-        else { return }
-        ghostty_surface_refresh(handle)
     }
 }

--- a/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/InMemoryTerminalSessionHostBytesTests.swift
+++ b/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/InMemoryTerminalSessionHostBytesTests.swift
@@ -86,6 +86,7 @@ struct InMemoryTerminalSessionHostBytesTests {
         }
         session.onHostBytes = { recorder.append("notify") }
         session.setSurface(fakeSurface)
+        session.armResizeDispatch(syncedWidthPixels: 640, syncedHeightPixels: 480)
         recorder.reset()
 
         let completed = DispatchSemaphore(value: 0)

--- a/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/InMemoryTerminalSessionHostBytesTests.swift
+++ b/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/InMemoryTerminalSessionHostBytesTests.swift
@@ -3,12 +3,12 @@ import Foundation
 import GhosttyKit
 import Testing
 
-/// Locks the render-arming contract of host-fed sessions: every byte fed
+/// Locks the refresh-request contract of host-fed sessions: every byte fed
 /// while a surface is attached must fire `onHostBytes` (which the surface
-/// coordinator wires to its render pump), and an attach that flushes
+/// coordinator wires to its refresh scheduler), and an attach that flushes
 /// buffered bytes must fire it too. This is the regression suite for the
 /// "blank/stale regions until a manual resize" bug: bytes were written
-/// into the surface but nothing armed the pump, so the core's coalesced
+/// into the surface but nothing requested a refresh, so the core's coalesced
 /// render wakeups let freshly parsed output sit on a stale frame.
 struct InMemoryTerminalSessionHostBytesTests {
     /// Thread-safe event recorder (the session's callbacks are @Sendable).

--- a/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalLifecycleTests.swift
+++ b/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalLifecycleTests.swift
@@ -75,18 +75,50 @@ struct TerminalLifecycleTests {
     }
 
     @Test
-    func `suspended wakeup does not schedule render`() {
+    func `hidden wakeup delivers callbacks without rendering`() {
         let controller = TerminalController()
+        let coordinator = TerminalSurfaceCoordinator()
         var wakeups = 0
+        var renders = 0
 
-        controller.shouldProcessWakeup = { false }
+        coordinator.isAttached = { true }
+        coordinator.setDisplayVisible(false)
+        coordinator.onPostRender = { renders += 1 }
         controller.onWakeup = {
             wakeups += 1
+            coordinator.requestImmediateTick()
         }
 
         controller.handleWakeup()
+        coordinator.renderImmediately()
 
-        #expect(wakeups == 0)
+        #expect(wakeups == 1)
+        #expect(renders == 0)
+    }
+
+    @Test
+    func `hidden ancestor blocks rendering and adoption restores it`() {
+        let coordinator = TerminalSurfaceCoordinator()
+        var presented = false
+        var renders = 0
+        coordinator.isAttached = { true }
+        coordinator.isPresented = { presented }
+        coordinator.onPostRender = { renders += 1 }
+
+        coordinator.refreshPresentationVisibility()
+        coordinator.noteRenderActivity()
+        coordinator.renderImmediately(synchronousDraw: true)
+        #expect(renders == 0)
+
+        presented = true
+        coordinator.refreshPresentationVisibility()
+        coordinator.renderImmediately(synchronousDraw: true)
+        #expect(renders == 1)
+
+        coordinator.isAttached = { false }
+        coordinator.stopRendering()
+        coordinator.renderImmediately()
+        #expect(renders == 1)
     }
 
     @Test

--- a/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalRenderSchedulerTests.swift
+++ b/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalRenderSchedulerTests.swift
@@ -56,7 +56,7 @@ struct TerminalRenderSchedulerTests {
         scheduler.request()
         let old = queue.take()
         scheduler.setEnabled(false)
-        #expect(old.allSatisfy(\.isCancelled))
+        #expect(old.allSatisfy { $0.isCancelled })
         for _ in 0..<100 { scheduler.request() }
         #expect(queue.take().isEmpty)
 
@@ -144,7 +144,7 @@ struct TerminalRenderSchedulerTests {
         scheduler.request()
         let pending = queue.take()
         scheduler.cancel()
-        #expect(pending.allSatisfy(\.isCancelled))
+        #expect(pending.allSatisfy { $0.isCancelled })
         pending.forEach { $0.perform() }
         #expect(renders == 0)
         scheduler.request()

--- a/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalRenderSchedulerTests.swift
+++ b/clients/native/vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalRenderSchedulerTests.swift
@@ -1,0 +1,154 @@
+@testable import GhosttyTerminal
+import Foundation
+import Testing
+
+@MainActor
+struct TerminalRenderSchedulerTests {
+    private final class Queue: @unchecked Sendable {
+        private let lock = NSLock()
+        private var items: [DispatchWorkItem] = []
+
+        func enqueue(_ item: DispatchWorkItem) {
+            lock.lock()
+            items.append(item)
+            lock.unlock()
+        }
+
+        func take() -> [DispatchWorkItem] {
+            lock.lock()
+            defer { lock.unlock() }
+            let result = items
+            items.removeAll()
+            return result
+        }
+    }
+
+    @Test
+    func `burst produces one refresh and no idle tail`() {
+        let queue = Queue()
+        var renders = 0
+        let scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+        }
+        for _ in 0..<100 { scheduler.request() }
+        let batch = queue.take()
+        #expect(batch.count == 1)
+        batch.forEach { $0.perform() }
+        #expect(renders == 1)
+        #expect(queue.take().isEmpty)
+
+        // A later low-rate write earns one more refresh, never a timed tail.
+        scheduler.request()
+        let next = queue.take()
+        #expect(next.count == 1)
+        next.forEach { $0.perform() }
+        #expect(renders == 2)
+        #expect(queue.take().isEmpty)
+    }
+
+    @Test
+    func `occlusion cancels queued work and suppresses hidden host writes`() {
+        let queue = Queue()
+        var renders = 0
+        let scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+        }
+        scheduler.request()
+        let old = queue.take()
+        scheduler.setEnabled(false)
+        #expect(old.allSatisfy(\.isCancelled))
+        for _ in 0..<100 { scheduler.request() }
+        #expect(queue.take().isEmpty)
+
+        // Adoption schedules fresh work. A callback from before hiding must
+        // neither paint nor consume the newly queued request.
+        scheduler.setEnabled(true)
+        scheduler.request()
+        old.forEach { $0.perform() }
+        #expect(renders == 0)
+        let adopted = queue.take()
+        #expect(adopted.count == 1)
+        adopted.forEach { $0.perform() }
+        #expect(renders == 1)
+    }
+
+    @Test
+    func `concurrent host requests share one pending refresh`() {
+        let queue = Queue()
+        var renders = 0
+        let scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            scheduler.request()
+        }
+        let batch = queue.take()
+        #expect(batch.count == 1)
+        batch.forEach { $0.perform() }
+        #expect(renders == 1)
+    }
+
+    @Test
+    func `request during rendering is delivered in the next batch`() {
+        let queue = Queue()
+        var renders = 0
+        var scheduler: TerminalRenderScheduler!
+        defer { scheduler = nil }
+        scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+            if renders == 1 { scheduler.request() }
+        }
+        scheduler.request()
+        queue.take().forEach { $0.perform() }
+        #expect(renders == 1)
+        let next = queue.take()
+        #expect(next.count == 1)
+        next.forEach { $0.perform() }
+        #expect(renders == 2)
+        #expect(queue.take().isEmpty)
+    }
+
+    @Test
+    func `hidden replay writes every byte without scheduling frames`() {
+        let queue = Queue()
+        var renders = 0
+        var written = Data()
+        let scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+        }
+        let session = InMemoryTerminalSession(write: { _ in }, resize: { _ in })
+        session.writeBufferOverride = { written.append($0) }
+        session.onHostBytes = { scheduler.request() }
+        scheduler.setEnabled(false)
+        session.receive("buffered replay")
+        // The write override handles this fake pointer without calling Metal.
+        session.setSurface(UnsafeMutableRawPointer(bitPattern: 1)!)
+        session.receive(" plus live output")
+        #expect(String(decoding: written, as: UTF8.self) == "buffered replay plus live output")
+        #expect(queue.take().isEmpty)
+
+        scheduler.setEnabled(true)
+        scheduler.request()
+        queue.take().forEach { $0.perform() }
+        #expect(renders == 1)
+        session.clearSurface(ifMatches: UnsafeMutableRawPointer(bitPattern: 1)!)
+    }
+
+    @Test
+    func `synchronous draw cancels a redundant pending refresh`() {
+        let queue = Queue()
+        var renders = 0
+        let scheduler = TerminalRenderScheduler(enqueue: { queue.enqueue($0) }) {
+            renders += 1
+        }
+        scheduler.request()
+        let pending = queue.take()
+        scheduler.cancel()
+        #expect(pending.allSatisfy(\.isCancelled))
+        pending.forEach { $0.perform() }
+        #expect(renders == 0)
+        scheduler.request()
+        queue.take().forEach { $0.perform() }
+        #expect(renders == 1)
+    }
+}

--- a/clients/native/vendor/libghostty-spm/UNPEEL-PATCHES.md
+++ b/clients/native/vendor/libghostty-spm/UNPEEL-PATCHES.md
@@ -44,11 +44,10 @@ path dependency because these changes are not upstream yet:
    `Sources/GhosttyTerminal/Surface/TerminalSurface.swift` (was internal)
    so the host can run `scroll_to_bottom`.
 
-3. **Synchronous render exposed** — `AppTerminalView.renderImmediately()`
+3. **Synchronous render exposed.** `AppTerminalView.renderImmediately()`
    (new `open func`) calling `TerminalSurfaceCoordinator.renderImmediately()`
-   (was `private`, now internal). The default wakeup path defers the first
-   draw after a view re-attaches to the next runloop turn via
-   `DispatchQueue.main.async`, so swapping a retained terminal view into
+    (was `private`, now internal). The default wakeup path coalesces the first
+    refresh after a view re-attaches on the main queue, so swapping a retained terminal view into
    the hierarchy presents the stale pre-detach drawable for a frame or
    two. Unpeel calls this right after adopting + focusing a pane on
    session switch so the swap transaction already contains a fresh,
@@ -78,13 +77,10 @@ both are small and generally useful).
    explicitly select this queued path; live controller/config rebuilds stay
    synchronous because they immediately reuse the coordinator.
 
-6. **Immediate macOS scrollback repaint** — `AppTerminalView.scrollWheel`
-   opens the render pump (`noteRenderActivity()`) after forwarding a scroll
-   event, so repaints present at display cadence from the first wheel tick.
-   *(Reworked 2026-08-20 with patch 9's off-main pump: the previous
-   per-wheel-event `renderImmediately()` ran a full main-thread tick per
-   event; now both scrollback and mouse-captured TUIs ride the off-main
-   pump.)*
+6. **Coalesced macOS scrollback repaint.** `AppTerminalView.scrollWheel`
+   requests a refresh (`noteRenderActivity()`) after forwarding scroll input.
+   Wheel-event bursts share one queued refresh on main. Later PTY output
+   drives the core renderer, and host-fed writes explicitly request refreshes.
 
 7. *(cherry-pick, 2026-07-09)* **Upstream "Fix AppKit selection copy leak"
    (Lakr233/libghostty-spm#23, commit `65051461`)** applied — landed upstream
@@ -102,28 +98,33 @@ both are small and generally useful).
    button to fake ctrl+End — sending raw `ESC [1;5F` via `sendText` was
    mangled into literal text for kitty-protocol TUIs like Claude Code.
 
-9. **Activity-window render pump** (2026-07-09, added for the ghostty-tip
-   core; moved off the main thread 2026-08-20) — `TerminalSurfaceCoordinator`
-   runs a real display link (`MSDisplayLink`) for ~1s after every render
-   request, wakeup, or scroll input. The tip core coalesces wakeups/render
-   actions under IO load, so the old purely push-driven embedder sat on
-   stale frames: Claude's virtual-scroll repaints showed a long delay before
-   scrolling started, and jump-to-bottom redraws left a blank screen until a
-   window resize forced a frame. The pump *pulls* whatever the core queued
-   instead of waiting to be pushed.
-   Since 2026-08-20 the per-frame path never touches the main thread:
-   `TerminalActivityLinkRelay` holds the raw surface handle and calls
-   `ghostty_surface_refresh` directly on the display-link thread (a
-   renderer-mailbox push + async wakeup — the same call termio makes
-   cross-thread), so frame production stays at display rate even when the
-   main thread is busy with AppKit/SwiftUI work — matching the Ghostty
-   app's renderer-thread-driven frames. The refresh runs under the relay
-   lock and the coordinator clears the handle under the same lock before
-   freeing the surface, so a late frame can never race the free.
-   `ghostty_app_tick` is no longer pumped per frame; app ticks stay
-   wakeup-driven on main. In-memory host feeds arm the relay directly from
-   their transport thread (no main hop between host bytes and the next
-   frame). The lock gate keeps closed-window frames to one acquisition.
+9. **Event-driven refresh and hidden-pane occlusion** (2026-09-08).
+   `TerminalRenderScheduler` replaces the one-second display-rate pump.
+   Render actions, wakeups, scroll input, and completed host writes request
+   one refresh on the next main-queue turn. Requests before that delivery
+   share the pending refresh, without adding a timer delay. No refresh
+   tail or wrapper display-link subscription remains while idle.
+   The old claim of off-main delivery was incorrect: pinned MSDisplayLink
+   2.1.0 delivered the relay callbacks on main. This scheduler also delivers
+   on main; the core still owns asynchronous rendering and vsync.
+
+   Hidden ancestors, detached views, and window occlusion stop rendering,
+   cancel queued refreshes, and call `ghostty_surface_set_occlusion(false)`.
+   `ghostty_app_tick` stays wakeup-driven for every live app regardless of
+   visibility, so replay, title, exit, and other mailbox callbacks keep
+   progressing. Host bytes still parse while hidden; the scheduler ignores
+   their refresh requests until presentation resumes. No raw surface handle
+   crosses threads in this scheduler. Teardown cancels pending work before
+   freeing the surface. AppKit hide/unhide, reparent, and window-occlusion
+   callbacks update presentation independently of explicit host visibility.
+
+   Synchronous resize and adoption draws remain available. Adoption requests
+   a new refresh even without new output, and its synchronous draw cancels
+   any redundant queued refresh. Host-write/attach notification ordering,
+   scheduler coalescing/cancellation, and hidden callback delivery have unit
+   coverage. Live Metal replay must still verify scroll, cache adoption,
+   synchronized output, and remote replay freshness; unit tests do not
+   establish presentation quality or GPU savings.
 
 10. **Callback userdata lifetime hardened** — app wakeup callbacks now use a
    retained `TerminalControllerCallbackContext` that weakly references the

--- a/clients/shared/UnpeelShared/Sources/UnpeelShared/RemoteControlProtocol.swift
+++ b/clients/shared/UnpeelShared/Sources/UnpeelShared/RemoteControlProtocol.swift
@@ -5,7 +5,10 @@ import Security
 public enum RemoteControlProtocol {
     public static let version = 1
     public static let hostMajorVersion = 1
-    public static let hostMinorVersion = 19
+    public static let hostMinorVersion = 20
+    /// Opt in with raw=1 only when the feed never inserts bytes between pages.
+    /// iOS synchronization brackets require the default safe-boundary replies.
+    public static let rawOutputCapability = "session.output.raw"
     public static let resumableArtifactUploadCapability = "artifact.upload.resumable"
     public static let sessionOrderCapability = "session.order.set"
     public static let sessionRuntimeRestartCapability = "session.runtime.restart"

--- a/clients/shared/UnpeelShared/Tests/UnpeelSharedTests/RemoteControlProtocolTests.swift
+++ b/clients/shared/UnpeelShared/Tests/UnpeelSharedTests/RemoteControlProtocolTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import UnpeelShared
 
 final class RemoteControlProtocolTests: XCTestCase {
+    func testRawOutputRequiresExplicitAdvertisedCapability() throws {
+        let legacy = RemoteHostProtocolDescriptor(minorVersion: 19, capabilities: ["session.output.read"])
+        XCTAssertFalse(legacy.supports(RemoteControlProtocol.rawOutputCapability))
+        let current = try roundTrip(RemoteHostProtocolDescriptor(capabilities: ["session.output.read", RemoteControlProtocol.rawOutputCapability]))
+        XCTAssertTrue(current.supports(RemoteControlProtocol.rawOutputCapability))
+        XCTAssertTrue(current.isCompatible())
+    }
+
     func testHostProtocolDescriptorIsAdditiveAndMajorVersioned() throws {
         let descriptor = RemoteHostProtocolDescriptor(
             capabilities: ["host.bootstrap", "session.output.read", "future.capability"]

--- a/crates/unpeel-core/src/controller_protocol.rs
+++ b/crates/unpeel-core/src/controller_protocol.rs
@@ -10,7 +10,7 @@
 use serde::{Deserialize, Serialize};
 
 pub const HOST_PROTOCOL_MAJOR: u16 = 1;
-pub const HOST_PROTOCOL_MINOR: u16 = 19;
+pub const HOST_PROTOCOL_MINOR: u16 = 20;
 
 pub const NATIVE_HOST_CAPABILITIES: &[&str] = &[
     "approval.answer",
@@ -40,6 +40,7 @@ pub const NATIVE_HOST_CAPABILITIES: &[&str] = &[
     "session.notify_when_done.set",
     "session.order.set",
     "session.output.read",
+    "session.output.raw",
     "session.output.subscribe",
     "session.pin.set",
     "session.project.set",
@@ -85,6 +86,7 @@ pub const HEADLESS_HOST_CAPABILITIES: &[&str] = &[
     "session.metrics.read",
     "session.order.set",
     "session.output.read",
+    "session.output.raw",
     "session.output.subscribe",
     "session.pin.set",
     "session.project.set",

--- a/crates/unpeel-core/src/core_reactor.rs
+++ b/crates/unpeel-core/src/core_reactor.rs
@@ -1122,6 +1122,8 @@ struct JournalSession {
 /// A Session whose journal saw no bytes for this long drops its batch
 /// buffer capacity (it is re-grown from the next chunk).
 const JOURNAL_IDLE_RELEASE: Duration = Duration::from_secs(1);
+/// Bound each drain so a continuously busy producer cannot starve deadlines.
+const JOURNAL_MESSAGE_BATCH_MAX: usize = 64;
 
 impl JournalSession {
     /// Idle diet: once a quiet second has passed since the last chunk and
@@ -1168,7 +1170,7 @@ fn run_journal_writer(rx: mpsc::Receiver<JournalMsg>, reactor: ReactorHandle) {
             .map(|at| at + JOURNAL_FLUSH_INTERVAL)
             .min()
             .or_else(|| holds_capacity.then(|| now + JOURNAL_IDLE_RELEASE));
-        let message = match next_deadline {
+        let mut message = match next_deadline {
             Some(deadline) => match rx.recv_timeout(deadline.saturating_duration_since(now)) {
                 Ok(message) => Some(message),
                 Err(mpsc::RecvTimeoutError::Timeout) => None,
@@ -1179,83 +1181,102 @@ fn run_journal_writer(rx: mpsc::Receiver<JournalMsg>, reactor: ReactorHandle) {
                 Err(_) => return,
             },
         };
-        match message {
-            Some(JournalMsg::Open {
-                id,
-                writer,
-                pressure,
-            }) => {
-                sessions.insert(
+        let mut processed = 0;
+        loop {
+            match message.take() {
+                Some(JournalMsg::Open {
                     id,
-                    JournalSession {
-                        writer,
-                        pressure,
-                        pending: Vec::new(),
-                        first_pending_at: None,
-                        last_chunk_at: Instant::now(),
-                        error: None,
-                    },
-                );
-            }
-            Some(JournalMsg::Chunk { id, data }) => {
-                let Some(session) = sessions.get_mut(&id) else {
-                    continue;
-                };
-                let slot = session.pressure.slot.load(Ordering::Acquire);
-                let previous = session
-                    .pressure
-                    .backlog
-                    .fetch_sub(data.len(), Ordering::AcqRel);
-                let remaining = previous.saturating_sub(data.len());
-                if session.pressure.paused.load(Ordering::Acquire)
-                    && remaining < JOURNAL_BACKLOG_LOW_BYTES
-                {
-                    session.pressure.paused.store(false, Ordering::Release);
-                    reactor.send(Control::JournalDrained(slot));
+                    writer,
+                    pressure,
+                }) => {
+                    sessions.insert(
+                        id,
+                        JournalSession {
+                            writer,
+                            pressure,
+                            pending: Vec::new(),
+                            first_pending_at: None,
+                            last_chunk_at: Instant::now(),
+                            error: None,
+                        },
+                    );
                 }
-                session.last_chunk_at = Instant::now();
-                if session.error.is_none() {
-                    if session.pending.is_empty() {
-                        session.first_pending_at = Some(Instant::now());
+                Some(JournalMsg::Chunk { id, data }) => {
+                    let Some(session) = sessions.get_mut(&id) else {
+                        break;
+                    };
+                    let slot = session.pressure.slot.load(Ordering::Acquire);
+                    let previous = session
+                        .pressure
+                        .backlog
+                        .fetch_sub(data.len(), Ordering::AcqRel);
+                    let remaining = previous.saturating_sub(data.len());
+                    if session.pressure.paused.load(Ordering::Acquire)
+                        && remaining < JOURNAL_BACKLOG_LOW_BYTES
+                    {
+                        session.pressure.paused.store(false, Ordering::Release);
+                        reactor.send(Control::JournalDrained(slot));
                     }
-                    session.pending.extend_from_slice(&data);
-                    if session.pending.len() >= JOURNAL_BATCH_MAX_BYTES {
-                        session.flush();
-                    }
-                    if session.error.is_some() {
-                        reactor.send(Control::JournalFailed(slot));
-                    }
-                }
-            }
-            Some(JournalMsg::Flush { id, ack }) => {
-                let result = match sessions.get_mut(&id) {
-                    Some(session) => {
-                        session.flush();
-                        match session.error.clone() {
-                            Some(error) => Err(error),
-                            None => Ok(()),
+                    session.last_chunk_at = Instant::now();
+                    if session.error.is_none() {
+                        if session.pending.is_empty() {
+                            session.first_pending_at = Some(Instant::now());
+                        }
+                        session.pending.extend_from_slice(&data);
+                        if session.pending.len() >= JOURNAL_BATCH_MAX_BYTES {
+                            session.flush();
+                        }
+                        if session.error.is_some() {
+                            reactor.send(Control::JournalFailed(slot));
                         }
                     }
-                    None => Ok(()),
-                };
-                let _ = ack.send(result);
-            }
-            Some(JournalMsg::Close { id, ack }) => {
-                let result = match sessions.remove(&id) {
-                    Some(mut session) => {
-                        session.flush();
-                        // Drop the writer: closes the file and its retention
-                        // record like the old writer thread's exit did.
-                        match session.error.take() {
-                            Some(error) => Err(error),
-                            None => Ok(()),
+                }
+                Some(JournalMsg::Flush { id, ack }) => {
+                    let result = match sessions.get_mut(&id) {
+                        Some(session) => {
+                            session.flush();
+                            match session.error.clone() {
+                                Some(error) => Err(error),
+                                None => Ok(()),
+                            }
                         }
-                    }
-                    None => Ok(()),
-                };
-                let _ = ack.send(result);
+                        None => Ok(()),
+                    };
+                    let _ = ack.send(result);
+                }
+                Some(JournalMsg::Close { id, ack }) => {
+                    let result = match sessions.remove(&id) {
+                        Some(mut session) => {
+                            session.flush();
+                            // Drop the writer: closes the file and its retention
+                            // record like the old writer thread's exit did.
+                            match session.error.take() {
+                                Some(error) => Err(error),
+                                None => Ok(()),
+                            }
+                        }
+                        None => Ok(()),
+                    };
+                    let _ = ack.send(result);
+                }
+                None => {}
             }
-            None => {}
+            processed += 1;
+            // A newly queued first byte also needs a deadline even when the
+            // batch began with no pending writes. Bound elapsed work by the
+            // flush interval as well as the earliest pre-existing deadline.
+            if processed >= JOURNAL_MESSAGE_BATCH_MAX
+                || Instant::now()
+                    >= next_deadline
+                        .unwrap_or(now + JOURNAL_FLUSH_INTERVAL)
+                        .min(now + JOURNAL_FLUSH_INTERVAL)
+            {
+                break;
+            }
+            message = rx.try_recv().ok();
+            if message.is_none() {
+                break;
+            }
         }
         let now = Instant::now();
         let mut failed = Vec::new();
@@ -1290,7 +1311,7 @@ fn run_timer(rx: mpsc::Receiver<TimerMsg>) {
     loop {
         let now = Instant::now();
         let mut next_wake = now + HOST_TIMER_MAX_SLEEP;
-        for (_, session_jobs) in jobs.iter_mut() {
+        for session_jobs in jobs.values_mut() {
             session_jobs.retain_mut(|job| {
                 if now >= job.next_at {
                     let keep =
@@ -1359,6 +1380,74 @@ mod tests {
             control_tx,
             waker: Arc::new(Waker::new().unwrap()),
         }
+    }
+
+    #[test]
+    fn journal_batches_preserve_chunk_order_and_flush_close_barriers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("output.bin");
+        let file = std::fs::File::create(&path).unwrap();
+        let writer = RetainedOutputWriter::new(file, path.clone(), 0, 1 << 20, 1 << 20).unwrap();
+        let pressure = Arc::new(JournalBackpressure::default());
+        let (tx, rx) = mpsc::channel();
+        tx.send(JournalMsg::Open {
+            id: 1,
+            writer,
+            pressure: Arc::clone(&pressure),
+        })
+        .unwrap();
+        let mut expected = Vec::new();
+        // Queue several batches before starting the consumer.
+        for index in 0..(JOURNAL_MESSAGE_BATCH_MAX * 3) {
+            let data = format!("{index}\n").into_bytes();
+            pressure.backlog.fetch_add(data.len(), Ordering::Relaxed);
+            expected.extend_from_slice(&data);
+            tx.send(JournalMsg::Chunk { id: 1, data }).unwrap();
+        }
+        let (flush_tx, flush_rx) = mpsc::channel();
+        tx.send(JournalMsg::Flush {
+            id: 1,
+            ack: flush_tx,
+        })
+        .unwrap();
+        let reactor = reactor_handle_stub();
+        let thread = std::thread::spawn(move || run_journal_writer(rx, reactor));
+        flush_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), expected);
+        assert_eq!(pressure.backlog.load(Ordering::Acquire), 0);
+        pressure.backlog.fetch_add(4, Ordering::Relaxed);
+        tx.send(JournalMsg::Chunk {
+            id: 1,
+            data: b"tail".to_vec(),
+        })
+        .unwrap();
+        // No more messages: the first-pending deadline must flush this tail
+        // even after the burst was drained as one sequence of batches.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while std::fs::metadata(&path).unwrap().len() < (expected.len() + 4) as u64 {
+            assert!(
+                Instant::now() < deadline,
+                "quiet journal tail was not flushed"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let (close_tx, close_rx) = mpsc::channel();
+        tx.send(JournalMsg::Close {
+            id: 1,
+            ack: close_tx,
+        })
+        .unwrap();
+        close_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .unwrap();
+        expected.extend_from_slice(b"tail");
+        assert_eq!(std::fs::read(&path).unwrap(), expected);
+        drop(tx);
+        thread.join().unwrap();
     }
 
     #[test]

--- a/crates/unpeel-core/src/mcp_host.rs
+++ b/crates/unpeel-core/src/mcp_host.rs
@@ -2413,7 +2413,7 @@ fn tool_list_agents(_args: &Value) -> Result<String, String> {
             && security.permits_manifest(caller.as_ref(), manifest)
             && session_host::active_runtime_id(manifest).is_some()
     });
-    manifests.sort_by(|a, b| b.session.created_at.cmp(&a.session.created_at));
+    manifests.sort_by_key(|manifest| std::cmp::Reverse(manifest.session.created_at));
     let agents = manifests
         .iter()
         .filter_map(|manifest| agent_context_json(manifest, &activity))
@@ -2685,7 +2685,7 @@ fn tool_list_sessions(_args: &Value) -> Result<String, String> {
         manifest.state == HostedSessionState::Running
             && security.permits_manifest(caller.as_ref(), manifest)
     });
-    manifests.sort_by(|a, b| b.session.created_at.cmp(&a.session.created_at));
+    manifests.sort_by_key(|manifest| std::cmp::Reverse(manifest.session.created_at));
     let sessions: Vec<Value> = manifests
         .iter()
         .map(|manifest| {
@@ -3427,7 +3427,7 @@ fn group_peer_manifests_for_caller(
                 && security.permits_manifest(Some(&caller), manifest)
         })
         .collect();
-    peers.sort_by(|a, b| b.session.created_at.cmp(&a.session.created_at));
+    peers.sort_by_key(|manifest| std::cmp::Reverse(manifest.session.created_at));
 
     if let Some(only_ids) = only_ids {
         let found: HashSet<String> = peers

--- a/crates/unpeel-core/src/remote_server.rs
+++ b/crates/unpeel-core/src/remote_server.rs
@@ -1296,7 +1296,7 @@ fn api_sessions<W: Write>(stream: &mut W) {
     let activity = mcp_host::load_activity_state();
     let mut manifests = session_host::list_manifests();
     manifests.retain(|m| m.state == HostedSessionState::Running);
-    manifests.sort_by(|a, b| b.session.created_at.cmp(&a.session.created_at));
+    manifests.sort_by_key(|manifest| std::cmp::Reverse(manifest.session.created_at));
     let sessions: Vec<Value> = manifests
         .iter()
         .map(|m| session_json(m, &mcp_host::activity_status_for_manifest(&activity, m)))

--- a/crates/unpeel-core/src/remote_session_backend.rs
+++ b/crates/unpeel-core/src/remote_session_backend.rs
@@ -3051,6 +3051,9 @@ impl BackendInner {
         let mut call = HostCall::new("GET", OUTPUT_PATH, RequestSemantics::ReadOnly)
             .with_query("session_id", session_id)
             .with_query("limit", options.limit.to_string());
+        if accepted.value.snapshot.supports("session.output.raw") {
+            call = call.with_query("raw", "1");
+        }
         if let Some(offset) = token.requested_offset {
             call = call.with_query("offset", offset.to_string());
         }
@@ -5392,6 +5395,50 @@ mod tests {
         );
         assert!(!backend.needs_bootstrap());
         assert_eq!(connection.remaining(), 0);
+    }
+
+    #[test]
+    fn raw_output_is_requested_only_when_advertised_and_preserves_split_bytes() {
+        for advertised in [false, true] {
+            let connection = ScriptedConnection::new();
+            let generation = connection.generation(1);
+            let mut capabilities = vec![BOOTSTRAP_CAPABILITY, OUTPUT_CAPABILITY];
+            if advertised {
+                capabilities.push("session.output.raw");
+            }
+            add_bootstrap(
+                &connection,
+                generation,
+                bootstrap_json(Some("host-1"), HOST_PROTOCOL_MAJOR, Some(&capabilities)),
+            );
+            let mut expected = expected_output(generation, "s1", None);
+            if advertised {
+                expected.query.push(("raw".to_owned(), "1".to_owned()));
+            }
+            let bytes: &[u8] = if advertised {
+                b"\x1b]title\xe2\x82"
+            } else {
+                b"safe"
+            };
+            connection.push(reply_step(
+                expected,
+                generation,
+                200,
+                output_json("s1", 0, bytes, false),
+            ));
+            let backend = RemoteSessionBackend::new(connection.clone());
+            backend.bootstrap().unwrap();
+            let page = backend
+                .poll_output("s1", RemoteOutputPollOptions::default())
+                .unwrap();
+            assert_eq!(page.bytes(), bytes);
+            page.commit().unwrap();
+            assert_eq!(
+                backend.committed_output_offset("s1"),
+                Some(bytes.len() as u64)
+            );
+            assert_eq!(connection.remaining(), 0);
+        }
     }
 
     #[test]

--- a/crates/unpeel-core/src/runtime_observer.rs
+++ b/crates/unpeel-core/src/runtime_observer.rs
@@ -178,6 +178,45 @@ pub(crate) fn inspect_owned_session_processes(
     None
 }
 
+/// A positive retained-identity check is enough to keep a managed runtime
+/// blocked on routine observation ticks. A miss must still take the complete
+/// session scan: surviving process-group members also block shell recovery.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub(crate) fn retained_runtime_is_present(
+    session_leader_pid: u32,
+    session_leader_started_at_ms: u64,
+    prior: &ActiveRuntimeObservation,
+) -> bool {
+    // The leader may exec the final interactive shell without changing its
+    // start time. Leave that case to the executable/invocation inspection.
+    let Some(started_at) = prior.pid_started_at else {
+        return false;
+    };
+    if session_leader_pid <= 1
+        || prior.pid <= 1
+        || prior.pid == session_leader_pid
+        || prior.process_group_id <= 1
+    {
+        return false;
+    }
+    pid_start_matches(session_leader_pid, session_leader_started_at_ms)
+        && pid_start_matches(prior.pid, started_at)
+        && unsafe { libc::getsid(prior.pid as libc::pid_t) } == session_leader_pid as libc::pid_t
+        && unsafe { libc::getpgid(prior.pid as libc::pid_t) }
+            == prior.process_group_id as libc::pid_t
+        && pid_start_matches(prior.pid, started_at)
+        && pid_start_matches(session_leader_pid, session_leader_started_at_ms)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub(crate) fn retained_runtime_is_present(
+    _session_leader_pid: u32,
+    _session_leader_started_at_ms: u64,
+    _prior: &ActiveRuntimeObservation,
+) -> bool {
+    false
+}
+
 /// A fresh catalog miss is not proof that a previously observed job exited:
 /// the same process can `exec` an unrecognized binary, change its argv/title,
 /// or leave children in its old process group. Require both identities gone.
@@ -1062,6 +1101,37 @@ mod platform {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn retained_identity_requires_live_start_session_and_group() {
+        let pid = std::process::id();
+        let leader = u32::try_from(unsafe { libc::getsid(0) }).unwrap();
+        let group = u32::try_from(unsafe { libc::getpgid(0) }).unwrap();
+        let started = crate::session_host::process_start_time_ms(pid).unwrap();
+        let leader_started = crate::session_host::process_start_time_ms(leader).unwrap();
+        let mut prior = ActiveRuntimeObservation {
+            runtime_id: "test".into(),
+            pid,
+            pid_started_at: Some(started),
+            process_group_id: group,
+            process_name: "test".into(),
+            argv: None,
+        };
+        assert_eq!(
+            retained_runtime_is_present(leader, leader_started, &prior),
+            pid != leader && leader > 1 && group > 1,
+        );
+        prior.pid_started_at = Some(started.saturating_add(PID_START_TOLERANCE_MS + 1));
+        assert!(!retained_runtime_is_present(leader, leader_started, &prior));
+        prior.pid_started_at = Some(started);
+        prior.process_group_id = 0;
+        assert!(!retained_runtime_is_present(leader, leader_started, &prior));
+        prior.process_group_id = group;
+        assert!(!retained_runtime_is_present(pid, started, &prior));
+        prior.pid_started_at = None;
+        assert!(!retained_runtime_is_present(leader, leader_started, &prior));
+    }
 
     #[test]
     fn owned_shell_argv_requires_login_interactive_without_a_command() {

--- a/crates/unpeel-core/src/session_host.rs
+++ b/crates/unpeel-core/src/session_host.rs
@@ -464,6 +464,10 @@ impl ScreenChangeTracker {
             self.last_hash = Some(hash);
             self.changed_at = Some(now_ms);
         }
+        self.flush_due(now_ms)
+    }
+
+    fn flush_due(&mut self, now_ms: u64) -> Option<u64> {
         let pending = self.changed_at.filter(|c| Some(*c) != self.written_at)?;
         if self.written_at.is_some()
             && now_ms.saturating_sub(self.last_write_ms) < SCREEN_STAMP_COALESCE_MS
@@ -5452,7 +5456,19 @@ pub(crate) fn build_session_timer_jobs(inputs: SessionJobInputs) -> Vec<HostTime
                 {
                     if let Some(expected_runtime_id) = runtime_observer_expected_id.as_deref() {
                         let prior_observation = tracker.current.clone();
-                        if let Some(inspection) =
+                        if prior_observation.as_ref().is_some_and(|prior| {
+                            crate::runtime_observer::retained_runtime_is_present(
+                                session_leader_pid,
+                                session_leader_started_at_ms,
+                                prior,
+                            )
+                        }) {
+                            // The full scan gives this exact retained identity
+                            // precedence too. Only a miss needs discovery of
+                            // remaining group members and shell recovery.
+                            observation = prior_observation;
+                            returned_to_owned_shell = false;
+                        } else if let Some(inspection) =
                             crate::runtime_observer::inspect_owned_session_processes(
                                 session_leader_pid,
                                 session_leader_started_at_ms,
@@ -5614,19 +5630,31 @@ pub(crate) fn build_session_timer_jobs(inputs: SessionJobInputs) -> Vec<HostTime
         let mut last_modes: Option<crate::terminal_viewport::TerminalModeState> = None;
         let mut url_tracker = crate::local_urls::LocalUrlTracker::default();
         let mut screen_tracker = ScreenChangeTracker::default();
+        let mut screen_generation = None;
         let mut ticks_since_probe: u32 = 0;
         HostTimerJob::new(
             Duration::from_millis(SESSION_MENU_SCAN_INTERVAL_MS),
             Duration::from_millis(SESSION_MENU_SCAN_INTERVAL_MS),
             move || {
-                let (screen, modes) = {
+                let input = {
                     let mut viewport = viewport_for_menu.lock().unwrap();
-                    (
-                        viewport.current_screen_text(),
-                        viewport.terminal_mode_state(),
-                    )
+                    let generation = viewport.screen_generation();
+                    if screen_generation == Some(generation) {
+                        None
+                    } else {
+                        screen_generation = Some(generation);
+                        Some((
+                            viewport.current_screen_text(),
+                            viewport.terminal_mode_state(),
+                        ))
+                    }
                 };
-                if let Some(stamp) = screen_tracker.observe(&screen, current_timestamp_ms()) {
+                let now = current_timestamp_ms();
+                let stamp = match input.as_ref() {
+                    Some((screen, _)) => screen_tracker.observe(screen, now),
+                    None => screen_tracker.flush_due(now),
+                };
+                if let Some(stamp) = stamp {
                     let _ = update_manifest_session(&menu_session_id, |manifest| {
                         manifest.screen_changed_at = Some(stamp);
                     });
@@ -5634,20 +5662,23 @@ pub(crate) fn build_session_timer_jobs(inputs: SessionJobInputs) -> Vec<HostTime
                 // Edge-written like `menu_prompt_active`: steady state costs
                 // zero manifest writes; mode flips are rare (workload
                 // startup/exit, alt-screen apps opening a pager, …).
-                if last_modes.as_ref() != Some(&modes) {
-                    last_modes = Some(modes.clone());
-                    let _ = update_manifest_session(&menu_session_id, |manifest| {
-                        manifest.terminal_modes = (!modes.is_default()).then(|| modes.clone());
-                    });
+                let mut saw_new_url = false;
+                if let Some((screen, modes)) = input {
+                    if last_modes.as_ref() != Some(&modes) {
+                        last_modes = Some(modes.clone());
+                        let _ = update_manifest_session(&menu_session_id, |manifest| {
+                            manifest.terminal_modes = (!modes.is_default()).then(|| modes.clone());
+                        });
+                    }
+                    let active = viewport_has_menu_prompt(&screen);
+                    if active != last_active {
+                        last_active = active;
+                        let _ = update_manifest_session(&menu_session_id, |manifest| {
+                            manifest.menu_prompt_active = active;
+                        });
+                    }
+                    saw_new_url = url_tracker.observe_screen(&screen);
                 }
-                let active = viewport_has_menu_prompt(&screen);
-                if active != last_active {
-                    last_active = active;
-                    let _ = update_manifest_session(&menu_session_id, |manifest| {
-                        manifest.menu_prompt_active = active;
-                    });
-                }
-                let saw_new_url = url_tracker.observe_screen(&screen);
                 ticks_since_probe += 1;
                 if url_tracker.has_candidates()
                     && (saw_new_url || ticks_since_probe >= URL_PROBE_TICKS)
@@ -6433,9 +6464,10 @@ mod tests {
         // Content settles on "e" at 3.4s; the trailing change must still be
         // persisted once the window reopens, even with no further changes.
         assert_eq!(tracker.observe("e", 3_400), None);
-        assert_eq!(tracker.observe("e", 5_500), Some(3_400));
+        assert_eq!(tracker.flush_due(4_000), None);
+        assert_eq!(tracker.flush_due(5_500), Some(3_400));
         // Fully settled: no more writes.
-        assert_eq!(tracker.observe("e", 60_000), None);
+        assert_eq!(tracker.flush_due(60_000), None);
     }
 
     #[derive(Clone, Default)]

--- a/crates/unpeel-core/src/terminal_viewport.rs
+++ b/crates/unpeel-core/src/terminal_viewport.rs
@@ -780,12 +780,30 @@ fn style_color_string(color: &vt::GhosttyStyleColor) -> Option<String> {
 }
 
 fn read_row_cells(cells: vt::GhosttyRenderStateRowCells, with_styles: bool) -> TerminalViewportRow {
+    if !with_styles {
+        let mut text = String::new();
+        let default_style = CellStyle::default();
+        let mut text_end = 0;
+        while unsafe { vt::ghostty_render_state_row_cells_next(cells) } {
+            let (piece, _) = read_cell(cells, false, &default_style);
+            text.push_str(&piece);
+            if !piece.is_empty() && piece != " " {
+                text_end = text.len();
+            }
+        }
+        text.truncate(text_end);
+        return TerminalViewportRow {
+            text,
+            styles: Vec::new(),
+            wrapped: false,
+        };
+    }
     let mut pieces: Vec<String> = Vec::new();
     let mut cell_styles: Vec<CellStyle> = Vec::new();
     let mut previous_style = CellStyle::default();
 
     while unsafe { vt::ghostty_render_state_row_cells_next(cells) } {
-        let (text, style) = read_cell(cells, with_styles, &previous_style);
+        let (text, style) = read_cell(cells, true, &previous_style);
         previous_style = style.clone();
         pieces.push(text);
         cell_styles.push(style);
@@ -800,11 +818,7 @@ fn read_row_cells(cells: vt::GhosttyRenderStateRowCells, with_styles: bool) -> T
         .unwrap_or(0);
     let text: String = pieces[..text_end].concat();
 
-    let styles = if with_styles {
-        style_runs(&cell_styles)
-    } else {
-        Vec::new()
-    };
+    let styles = style_runs(&cell_styles);
     TerminalViewportRow {
         text,
         styles,
@@ -989,6 +1003,8 @@ pub struct TerminalViewportState {
     output_offset: u64,
     history_truncated: bool,
     apc_filter: KittyApcFilter,
+    /// Invalidates detector input independently of journal offsets and replay.
+    screen_generation: u64,
     /// Complete kitty APC sequences captured for passthrough, oldest first.
     /// Only populated when `set_graphics_capture(true)`; bounded by
     /// `MAX_CAPTURED_GRAPHICS` / `MAX_CAPTURED_APC_BYTES`.
@@ -1186,6 +1202,7 @@ impl TerminalViewportState {
             output_offset: 0,
             history_truncated: false,
             apc_filter: KittyApcFilter::default(),
+            screen_generation: 0,
             captured_graphics: Vec::new(),
         }
     }
@@ -1216,6 +1233,7 @@ impl TerminalViewportState {
         history_truncated: bool,
     ) {
         let capture = self.apc_filter.capture;
+        self.screen_generation = self.screen_generation.wrapping_add(1);
         self.term = VtTerminal::new(cols, rows);
         self.resize_replay.clear();
         self.output_offset = output_offset;
@@ -1266,6 +1284,9 @@ impl TerminalViewportState {
     }
 
     fn write_terminal(&mut self, bytes: &[u8]) {
+        if !bytes.is_empty() {
+            self.screen_generation = self.screen_generation.wrapping_add(1);
+        }
         self.term.write(bytes);
         if self.journal.is_some() {
             return;
@@ -1348,7 +1369,15 @@ impl TerminalViewportState {
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) {
+        if self.term.cols != cols || self.term.rows != rows {
+            self.screen_generation = self.screen_generation.wrapping_add(1);
+        }
         self.term.resize(cols, rows);
+    }
+
+    /// Read under the same lock as detector input to avoid racing output.
+    pub fn screen_generation(&self) -> u64 {
+        self.screen_generation
     }
 
     /// The exact lifetime journal offset up to which this VT has consumed
@@ -2364,6 +2393,51 @@ mod tests {
         // detector must clear.
         state.feed(b"\x1b[2J\x1b[HWorking on it\xe2\x80\xa6");
         assert!(!viewport_has_menu_prompt(&state.current_screen_text()));
+    }
+
+    #[test]
+    fn detector_generation_tracks_text_modes_resize_and_reset_not_offset() {
+        let mut state = TerminalViewportState::new(20, 4);
+        let initial = state.screen_generation();
+        state.feed(b"");
+        state.resize(20, 4);
+        state.set_output_offset(100);
+        state.feed(b"\x1b_Ga=T,f=24;AAAA\x1b\\");
+        assert_eq!(state.screen_generation(), initial);
+        state.feed(b"hello");
+        let painted = state.screen_generation();
+        assert_ne!(painted, initial);
+        state.current_screen_text();
+        state.snapshot(0, None);
+        assert_eq!(state.screen_generation(), painted);
+        state.feed(b"\x1b[?1006h");
+        let mode_changed = state.screen_generation();
+        assert_ne!(mode_changed, painted);
+        assert!(state.terminal_mode_state().set.contains(&1006));
+        state.resize(10, 4);
+        let resized = state.screen_generation();
+        assert_ne!(resized, mode_changed);
+        let offset = state.output_offset();
+        state.reset_at_output_offset(10, 4, offset, false);
+        assert_ne!(state.screen_generation(), resized);
+        assert_eq!(state.output_offset(), offset);
+        assert!(state.current_screen_text().trim().is_empty());
+    }
+
+    #[test]
+    fn text_only_rows_match_styled_rows_for_unicode_and_blanks() {
+        let mut state = TerminalViewportState::new(24, 5);
+        state.feed("\x1b[31m中 e\u{301}  x  \r\n\tend\r\n\x1b[44m  \x1b[K".as_bytes());
+        state.term.scroll_bottom();
+        let styled = state.term.viewport_rows(true);
+        let plain = state.term.viewport_rows(false);
+        assert_eq!(plain.len(), styled.len());
+        for (plain, styled) in plain.iter().zip(&styled) {
+            assert_eq!(plain.text, styled.text);
+            assert_eq!(plain.wrapped, styled.wrapped);
+            assert!(plain.styles.is_empty());
+        }
+        assert!(plain[0].text.contains("中 e\u{301}  x"));
     }
 
     #[test]

--- a/crates/unpeel-serve/src/driver.rs
+++ b/crates/unpeel-serve/src/driver.rs
@@ -1952,8 +1952,14 @@ impl Drop for HostRuntime {
 pub fn run(mut report: impl FnMut(ServeEvent)) -> Result<(), String> {
     SHUTDOWN_REQUESTED.store(false, Ordering::Release);
     unsafe {
-        libc::signal(libc::SIGINT, request_shutdown as libc::sighandler_t);
-        libc::signal(libc::SIGTERM, request_shutdown as libc::sighandler_t);
+        libc::signal(
+            libc::SIGINT,
+            request_shutdown as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGTERM,
+            request_shutdown as *const () as libc::sighandler_t,
+        );
     }
     let (mut driver, events) = HostRuntime::start()?;
     for event in events {

--- a/crates/unpeel-serve/src/mobile.rs
+++ b/crates/unpeel-serve/src/mobile.rs
@@ -934,80 +934,179 @@ pub(crate) fn principal_for_bearer(
         })
 }
 
-/// ANSI/UTF-8 boundary scan (port of `align_tail_start_in_window`): returns
-/// the last safe boundary at or before `data.len()`, scanning from 0.
-fn last_safe_boundary(data: &[u8]) -> usize {
-    #[derive(PartialEq)]
-    enum S {
+fn prepare_output_chunk(
+    mut chunk: unpeel_core::session_host::SessionOutputChunk,
+    limit: usize,
+    raw: bool,
+) -> Result<unpeel_core::session_host::SessionOutputChunk, String> {
+    // Replay-start alignment may extend the core read backwards. Keep the
+    // wire page within the Controller's limit, including relay frame budgets.
+    if chunk.data.len() > limit {
+        chunk.next_offset -= (chunk.data.len() - limit) as u64;
+        chunk.data.truncate(limit);
+    }
+    if raw {
+        Ok(chunk)
+    } else {
+        legacy_output_chunk(chunk, limit)
+    }
+}
+
+/// Legacy Controllers inject VT bytes between replies. Only return complete
+/// scalars and ground-state VT prefixes, including on replay/reset pages.
+fn legacy_output_chunk(
+    mut chunk: unpeel_core::session_host::SessionOutputChunk,
+    limit: usize,
+) -> Result<unpeel_core::session_host::SessionOutputChunk, String> {
+    let safe = legacy_output_prefix_len(&chunk.data);
+    if safe == 0 && !chunk.data.is_empty() && (chunk.data.len() >= limit || chunk.exited) {
+        return Err("terminal output has no safe boundary within the requested limit; use a Controller supporting session.output.raw or increase limit (maximum 8 MiB)".to_owned());
+    }
+    chunk.next_offset -= (chunk.data.len() - safe) as u64;
+    chunk.data.truncate(safe);
+    Ok(chunk)
+}
+
+fn legacy_output_prefix_len(data: &[u8]) -> usize {
+    #[derive(Clone, Copy, PartialEq)]
+    enum State {
         Ground,
         Esc,
+        Intermediate,
         Csi,
-        Osc,
-        OscEsc,
+        String(bool),
+        StringEsc(bool),
     }
-    let mut state = S::Ground;
-    let mut boundary = 0usize;
-    let mut i = 0usize;
+    let mut state = State::Ground;
+    let mut safe = 0;
+    let mut i = 0;
     while i < data.len() {
-        let b = data[i];
-        match state {
-            S::Ground => match b {
-                0x1b => state = S::Esc,
-                0x80..=0xbf => {} // utf-8 continuation: not a boundary start
-                _ => {
-                    // boundary after complete utf-8 scalar
-                    let len = if b < 0x80 {
-                        1
-                    } else if b >= 0xf0 {
-                        4
-                    } else if b >= 0xe0 {
-                        3
-                    } else {
-                        2
+        let byte = data[i];
+        if matches!(byte, 0x18 | 0x1a) {
+            state = State::Ground;
+        } else {
+            state = match state {
+                State::Ground if byte == 0x1b => State::Esc,
+                State::Ground => {
+                    let width = match byte {
+                        0xc2..=0xdf => 2,
+                        0xe0..=0xef => 3,
+                        0xf0..=0xf4 => 4,
+                        _ => 1,
                     };
-                    if i + len <= data.len() {
-                        i += len;
-                        boundary = i;
-                        continue;
-                    } else {
-                        break;
+                    let available = &data[i..(i + width).min(data.len())];
+                    match std::str::from_utf8(available) {
+                        Err(error) if error.error_len().is_none() => break,
+                        Ok(_) => i += width - 1,
+                        _ => {} // Invalid bytes still travel verbatim.
                     }
+                    State::Ground
                 }
-            },
-            S::Esc => match b {
-                b'[' => state = S::Csi,
-                b']' | b'P' | b'X' | b'^' | b'_' => state = S::Osc,
-                _ => {
-                    state = S::Ground;
-                    boundary = i + 1;
-                }
-            },
-            S::Csi => {
-                if (0x40..=0x7e).contains(&b) {
-                    state = S::Ground;
-                    boundary = i + 1;
-                }
-            }
-            S::Osc => match b {
-                0x07 => {
-                    state = S::Ground;
-                    boundary = i + 1;
-                }
-                0x1b => state = S::OscEsc,
-                _ => {}
-            },
-            S::OscEsc => {
-                state = if b == b'\\' {
-                    boundary = i + 1;
-                    S::Ground
-                } else {
-                    S::Osc
-                };
-            }
+                State::Esc => match byte {
+                    b'[' => State::Csi,
+                    b']' => State::String(true),
+                    b'P' | b'X' | b'^' | b'_' => State::String(false),
+                    0x20..=0x2f => State::Intermediate,
+                    0x1b => State::Esc,
+                    0x00..=0x1f => State::Esc,
+                    _ => State::Ground,
+                },
+                State::Intermediate | State::Csi if byte == 0x1b => State::Esc,
+                State::Intermediate if (0x30..=0x7e).contains(&byte) => State::Ground,
+                State::Csi if (0x40..=0x7e).contains(&byte) => State::Ground,
+                State::String(true) | State::StringEsc(true) if byte == 0x07 => State::Ground,
+                State::String(osc) if byte == 0x1b => State::StringEsc(osc),
+                State::StringEsc(_) if byte == b'\\' => State::Ground,
+                State::StringEsc(osc) if byte != 0x1b => State::String(osc),
+                other => other,
+            };
         }
         i += 1;
+        if state == State::Ground {
+            safe = i;
+        }
     }
-    boundary
+    safe
+}
+
+/// Coalesce an incomplete UTF-8 suffix, but preserve invalid bytes verbatim.
+/// Unlike replay *start* alignment, continuation pages must not require VT
+/// ground state: the Controller retains its parser across pages, including
+/// inside arbitrarily large OSC/APC strings. Never buffer a whole string here.
+fn output_prefix_len(data: &[u8], limit: usize, exited: bool) -> usize {
+    if data.len() >= limit || exited {
+        // Even a one-byte page must progress. The retained parser also handles
+        // split scalars; this is byte transport, not independent text records.
+        return data.len();
+    }
+    let mut start = 0;
+    while start < data.len() {
+        match std::str::from_utf8(&data[start..]) {
+            Ok(_) => return data.len(),
+            Err(error) => {
+                start += error.valid_up_to();
+                match error.error_len() {
+                    Some(len) => start += len,
+                    None => return start,
+                }
+            }
+        }
+    }
+    data.len()
+}
+
+type OutputFingerprint = [Option<(u64, u64, Option<std::time::SystemTime>)>; 3];
+
+fn output_fingerprint(paths: &[std::path::PathBuf; 3]) -> OutputFingerprint {
+    use std::os::unix::fs::MetadataExt;
+
+    paths.each_ref().map(|path| {
+        std::fs::metadata(path)
+            .ok()
+            .map(|metadata| (metadata.len(), metadata.ino(), metadata.modified().ok()))
+    })
+}
+
+// Match core's manifest-health cache lifetime. Even without a file change,
+// process death must eventually go through the authoritative health reader.
+const OUTPUT_HEALTH_RECHECK: Duration = Duration::from_millis(500);
+
+fn poll_output_chunk(
+    offset: Option<u64>,
+    limit: usize,
+    wait: Duration,
+    mut fingerprint: impl FnMut() -> OutputFingerprint,
+    mut read: impl FnMut() -> Result<unpeel_core::session_host::SessionOutputChunk, String>,
+) -> Result<(u64, Vec<u8>, bool), String> {
+    let deadline = Instant::now() + wait;
+    loop {
+        // Sample before reading so a concurrent append or retention update
+        // cannot be mistaken for the state of the cached empty result.
+        let observed = fingerprint();
+        let chunk = read()?;
+        let health_deadline = Instant::now() + OUTPUT_HEALTH_RECHECK;
+        let start = chunk.next_offset.saturating_sub(chunk.data.len() as u64);
+        let truncated = offset.map_or(start > 0, |requested| requested != start);
+        let mut data = chunk.data;
+        if !truncated {
+            data.truncate(output_prefix_len(&data, limit, chunk.exited));
+        }
+        if !data.is_empty() || truncated || chunk.exited || offset.is_none() {
+            return Ok((start, data, truncated));
+        }
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok((start, data, truncated));
+            }
+            std::thread::sleep(remaining.min(Duration::from_millis(20)));
+            // These stats avoid journal reads, retention JSON parsing and
+            // manifest-health work on each idle tick. Cache only this request.
+            if fingerprint() != observed || Instant::now() >= health_deadline {
+                break;
+            }
+        }
+    }
 }
 
 const B64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -1250,7 +1349,6 @@ fn handle_output(request: &Request) -> (u16, String) {
     else {
         return (400, error_body("invalid session id"));
     };
-    let path = session_dir(session_id).join("output.bin");
     let limit = request
         .query
         .get("limit")
@@ -1268,38 +1366,33 @@ fn handle_output(request: &Request) -> (u16, String) {
         .unwrap_or(0)
         .min(25_000);
 
-    let mut size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-    if wait_ms > 0 {
-        if let Some(offset) = offset {
-            if offset == size {
-                let deadline = Instant::now() + Duration::from_millis(wait_ms);
-                while Instant::now() < deadline {
-                    std::thread::sleep(Duration::from_millis(20));
-                    size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-                    if size > offset {
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    let chunk = match unpeel_core::session_host::read_output_chunk(
-        session_id,
+    let dir = session_dir(session_id);
+    // Raw continuation requires a retained parser with no injected bytes
+    // between pages. Older Controllers omit this explicit opt-in.
+    let raw = request.query.get("raw").is_some_and(|value| value == "1");
+    let watched_paths = [
+        dir.join("output.bin"),
+        dir.join(unpeel_core::session_host::OUTPUT_RETENTION_FILE),
+        dir.join("manifest.json"),
+    ];
+    let (start, data, truncated) = match poll_output_chunk(
         offset,
-        Some(limit as usize),
-        Some(limit as usize),
+        limit as usize,
+        Duration::from_millis(wait_ms),
+        || output_fingerprint(&watched_paths),
+        || {
+            let chunk = unpeel_core::session_host::read_output_chunk(
+                session_id,
+                offset,
+                Some(limit as usize),
+                Some(limit as usize),
+            )?;
+            prepare_output_chunk(chunk, limit as usize, raw)
+        },
     ) {
         Ok(chunk) => chunk,
         Err(error) => return (500, error_body(&error)),
     };
-    let start = chunk.next_offset.saturating_sub(chunk.data.len() as u64);
-    let truncated = offset.map_or(start > 0, |requested| requested != start);
-    let mut data = chunk.data;
-    if !truncated {
-        let boundary = last_safe_boundary(&data);
-        data.truncate(boundary);
-    }
     let body = serde_json::json!({
         "sessionID": session_id,
         "offset": start,
@@ -3810,12 +3903,324 @@ non-ephemeral ports — a product regression, not a port race. Attempts: {failur
     }
 
     #[test]
-    fn boundary_withholds_partial_escape() {
-        assert_eq!(last_safe_boundary(b"hello \x1b[31m red"), 15);
-        assert_eq!(last_safe_boundary(b"hello \x1b[3"), 6);
-        assert_eq!(last_safe_boundary(b"plain"), 5);
-        // partial utf-8 tail withheld
-        assert_eq!(last_safe_boundary(&[b'a', 0xe2, 0x82]), 1);
+    fn output_prefix_preserves_control_and_invalid_bytes() {
+        assert_eq!(output_prefix_len(b"hello \x1b[3", 512, false), 9);
+        assert_eq!(output_prefix_len(&[b'a', 0xe2, 0x82], 512, false), 1);
+        assert_eq!(output_prefix_len(&[0xff, 0xe2, 0x82], 512, false), 1);
+        assert_eq!(output_prefix_len(&[0xe2], 1, false), 1);
+        assert_eq!(output_prefix_len(&[0xe2, 0x82], 512, true), 2);
+    }
+
+    #[test]
+    fn legacy_output_keeps_utf8_and_vt_boundaries_before_injected_brackets() {
+        for sequence in [
+            "€".as_bytes(),
+            b"\x1b]title\x07",
+            b"\x1b_payload\x1b\\",
+            b"\x1bPdata\x07more\x1b\\",
+            b"\x1b[31m",
+            b"\x1b(B",
+        ] {
+            for split in 1..sequence.len() {
+                let mut bytes = b"ok".to_vec();
+                bytes.extend_from_slice(&sequence[..split]);
+                let chunk = legacy_output_chunk(output_chunk(7, &bytes), bytes.len()).unwrap();
+                assert_eq!(chunk.data, b"ok");
+                assert_eq!(chunk.next_offset, 9);
+            }
+            assert_eq!(legacy_output_prefix_len(sequence), sequence.len());
+        }
+        assert_eq!(legacy_output_prefix_len(b"\xffok"), 3);
+    }
+
+    #[test]
+    fn aligned_replay_still_respects_wire_limit_and_legacy_boundaries() {
+        let bytes = b"\x1b]title\x07rest";
+        let raw = prepare_output_chunk(output_chunk(7, bytes), 4, true).unwrap();
+        assert_eq!(raw.data, &bytes[..4]);
+        assert_eq!(raw.next_offset, 11);
+        assert!(prepare_output_chunk(output_chunk(7, bytes), 4, false).is_err());
+        let safe = prepare_output_chunk(output_chunk(7, bytes), 9, false).unwrap();
+        assert_eq!(safe.data, &bytes[..9]);
+        assert_eq!(safe.next_offset, 16);
+    }
+
+    #[test]
+    fn legacy_oversized_strings_and_tiny_scalars_fail_with_bounded_error() {
+        for introducer in b"]_P" {
+            let mut bytes = vec![0x1b, *introducer];
+            bytes.resize(200 * 1024, b'x');
+            let error = legacy_output_chunk(output_chunk(0, &bytes), bytes.len()).unwrap_err();
+            assert!(error.contains("no safe boundary"));
+            assert!(error.contains("session.output.raw"));
+            // Below the bound an incomplete sequence waits at its exact cursor.
+            let pending = legacy_output_chunk(output_chunk(7, &bytes[..10]), bytes.len()).unwrap();
+            assert!(pending.data.is_empty());
+            assert_eq!(pending.next_offset, 7);
+        }
+        assert!(legacy_output_chunk(output_chunk(0, &[0xe2]), 1).is_err());
+        let mut exited = output_chunk(0, b"\x1b]unfinished");
+        exited.exited = true;
+        assert!(legacy_output_chunk(exited, 512).is_err());
+    }
+
+    #[test]
+    fn legacy_incomplete_control_string_long_poll_uses_metadata_and_keeps_cursor() {
+        let mut reads = 0;
+        let began = Instant::now();
+        let page = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_millis(45),
+            || [None; 3],
+            || {
+                reads += 1;
+                legacy_output_chunk(output_chunk(7, b"\x1b]unfinished"), 512)
+            },
+        )
+        .unwrap();
+        assert!(began.elapsed() >= Duration::from_millis(45));
+        assert_eq!(reads, 1);
+        assert_eq!(page, (7, vec![], false));
+    }
+
+    // Inject journal reads so these timing/cursor tests never access a real
+    // UNPEEL_HOME or depend on process-global environment mutation.
+    fn output_chunk(start: u64, bytes: &[u8]) -> unpeel_core::session_host::SessionOutputChunk {
+        unpeel_core::session_host::SessionOutputChunk {
+            data: bytes.to_vec(),
+            next_offset: start + bytes.len() as u64,
+            exited: false,
+            exists: true,
+        }
+    }
+
+    #[test]
+    fn output_long_poll_waits_for_deliverable_utf8_and_keeps_cursor_on_timeout() {
+        let began = Instant::now();
+        let mut reads = 0;
+        let (start, data, truncated) = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_millis(45),
+            || [None; 3],
+            || {
+                reads += 1;
+                Ok(output_chunk(7, &[0xe2, 0x82]))
+            },
+        )
+        .unwrap();
+        assert!(began.elapsed() >= Duration::from_millis(45));
+        assert_eq!(reads, 1, "unchanged incomplete suffix is read only once");
+        assert_eq!(start, 7);
+        assert!(data.is_empty());
+        assert!(!truncated);
+
+        let mut reads = 0;
+        let mut generation = 0;
+        let (start, data, truncated) = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_secs(1),
+            || {
+                generation += 1;
+                [Some((generation, 0, None)), None, None]
+            },
+            || {
+                reads += 1;
+                Ok(output_chunk(
+                    7,
+                    if reads == 1 {
+                        &[0xe2, 0x82]
+                    } else {
+                        &[0xe2, 0x82, 0xac]
+                    },
+                ))
+            },
+        )
+        .unwrap();
+        assert_eq!(reads, 2);
+        assert_eq!(start + data.len() as u64, 10);
+        assert_eq!(data, "€".as_bytes());
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn output_empty_poll_waits_but_cursor_reset_returns_immediately() {
+        let began = Instant::now();
+        let page = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_millis(25),
+            || [None; 3],
+            || Ok(output_chunk(7, &[])),
+        )
+        .unwrap();
+        assert!(began.elapsed() >= Duration::from_millis(25));
+        assert_eq!(page, (7, vec![], false));
+        let mut reads = 0;
+        let page = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_secs(1),
+            || [None; 3],
+            || {
+                reads += 1;
+                Ok(output_chunk(9, &[]))
+            },
+        )
+        .unwrap();
+        assert_eq!(reads, 1);
+        assert_eq!(page, (9, vec![], true));
+    }
+
+    #[test]
+    fn output_idle_ticks_use_metadata_until_the_health_deadline() {
+        let mut probes = 0;
+        let mut reads = 0;
+        let began = Instant::now();
+        let page = poll_output_chunk(
+            Some(7),
+            512,
+            Duration::from_secs(2),
+            || {
+                probes += 1;
+                [None; 3]
+            },
+            || {
+                reads += 1;
+                let mut chunk = output_chunk(7, &[]);
+                // Model process death with no journal or manifest write.
+                chunk.exited = reads == 2;
+                Ok(chunk)
+            },
+        )
+        .unwrap();
+        assert_eq!(reads, 2);
+        assert!(probes > reads);
+        assert!(began.elapsed() >= OUTPUT_HEALTH_RECHECK);
+        assert_eq!(page, (7, vec![], false));
+    }
+
+    #[test]
+    fn output_file_changes_wake_bytes_retention_and_exit_without_idle_full_reads() {
+        // All files are private fixtures, never the operator's UNPEEL_HOME.
+        let home = scratch_dir("output-poll");
+        std::fs::create_dir_all(&home).unwrap();
+        let paths = [
+            home.join("output.bin"),
+            home.join("output-retention.json"),
+            home.join("manifest.json"),
+        ];
+        for changed in 0..paths.len() {
+            for path in &paths {
+                std::fs::write(path, b"x").unwrap();
+            }
+            let mut probes = 0;
+            let mut reads = 0;
+            let page = poll_output_chunk(
+                Some(7),
+                512,
+                Duration::from_secs(2),
+                || {
+                    probes += 1;
+                    if probes == 3 {
+                        if changed == 0 {
+                            // Journal growth completes the withheld scalar.
+                            std::fs::write(&paths[changed], b"xx").unwrap();
+                        } else {
+                            // Atomic state replacement can keep the same size.
+                            let replacement = home.join("replacement");
+                            std::fs::write(&replacement, b"y").unwrap();
+                            std::fs::rename(replacement, &paths[changed]).unwrap();
+                        }
+                    }
+                    output_fingerprint(&paths)
+                },
+                || {
+                    reads += 1;
+                    if reads == 1 {
+                        return Ok(output_chunk(7, &[0xe2, 0x82]));
+                    }
+                    Ok(match changed {
+                        0 => output_chunk(7, &[0xe2, 0x82, 0xac]),
+                        1 => output_chunk(9, &[]),
+                        _ => {
+                            let mut chunk = output_chunk(7, &[0xe2, 0x82]);
+                            chunk.exited = true;
+                            chunk
+                        }
+                    })
+                },
+            )
+            .unwrap();
+            assert_eq!(reads, 2, "idle metadata tick must not read the journal");
+            assert_eq!(probes, 4, "change wakes on its first metadata sample");
+            match changed {
+                0 => assert_eq!(page, (7, "€".as_bytes().to_vec(), false)),
+                1 => assert_eq!(page, (9, vec![], true)),
+                _ => assert_eq!(page, (7, vec![0xe2, 0x82], false)),
+            }
+        }
+        std::fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn output_tiny_pages_preserve_split_utf8_without_resetting_the_parser() {
+        let journal = "a€😀z".as_bytes();
+        for limit in 1..=4 {
+            let mut cursor = 0;
+            let mut received = Vec::new();
+            while cursor < journal.len() {
+                let end = (cursor + limit).min(journal.len());
+                let (start, data, truncated) = poll_output_chunk(
+                    Some(cursor as u64),
+                    limit,
+                    Duration::ZERO,
+                    || [None; 3],
+                    || Ok(output_chunk(cursor as u64, &journal[cursor..end])),
+                )
+                .unwrap();
+                assert_eq!(start, cursor as u64);
+                assert!(!truncated);
+                assert!(!data.is_empty());
+                cursor += data.len();
+                received.extend(data);
+            }
+            assert_eq!(received, journal);
+        }
+    }
+
+    #[test]
+    fn output_oversized_control_strings_progress_byte_exactly_in_bounded_pages() {
+        for &introducer in b"]_" {
+            let mut journal = vec![0x1b, introducer];
+            journal.extend(vec![b'x'; 1024 * 1024]);
+            // Include controls and split ST: no page-local VT interpretation
+            // may drop or rewrite payload or reset the Controller's parser.
+            journal.extend_from_slice(b"\x07\x1b[3\x18\x1b\\done");
+            for limit in [1, 127, 512 * 1024] {
+                let mut cursor = 0;
+                while cursor < journal.len() {
+                    let end = (cursor + limit).min(journal.len());
+                    let (start, data, truncated) = poll_output_chunk(
+                        Some(cursor as u64),
+                        limit,
+                        Duration::ZERO,
+                        || [None; 3],
+                        || Ok(output_chunk(cursor as u64, &journal[cursor..end])),
+                    )
+                    .unwrap();
+                    assert_eq!(start, cursor as u64);
+                    assert!(!truncated);
+                    assert!(!data.is_empty());
+                    assert!(data.len() <= limit);
+                    assert_eq!(data, journal[cursor..cursor + data.len()]);
+                    cursor += data.len();
+                }
+                assert_eq!(cursor, journal.len());
+            }
+        }
     }
 
     #[test]

--- a/crates/unpeel-serve/src/service.rs
+++ b/crates/unpeel-serve/src/service.rs
@@ -485,8 +485,14 @@ fn publish_status(
 pub fn run_service(mut report: impl FnMut(ServiceEvent)) -> Result<(), String> {
     SHUTDOWN_REQUESTED.store(false, Ordering::Release);
     unsafe {
-        libc::signal(libc::SIGINT, request_shutdown as libc::sighandler_t);
-        libc::signal(libc::SIGTERM, request_shutdown as libc::sighandler_t);
+        libc::signal(
+            libc::SIGINT,
+            request_shutdown as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGTERM,
+            request_shutdown as *const () as libc::sighandler_t,
+        );
     }
     let real_home = unpeel_core::app_paths::real_unpeel_home();
     let lease = ServiceLease::acquire(&real_home)?;

--- a/docs/agents/clients/terminal.md
+++ b/docs/agents/clients/terminal.md
@@ -68,6 +68,28 @@ The native terminal is a **libghostty** surface (GhosttyKit), Metal-rendered, no
   config so its theme, keybind clearing, and padding stay in control.
 - Agent TUIs that repaint the screen in place can still appear to "crop" or "overwrite" detail while streaming — normal terminal behavior; intermediate full-screen redraw states are not guaranteed to survive as scrollback.
 
+### Rendering and retained panes
+
+Renderer visibility and callback processing are separate. A detached pane, a
+pane under a hidden ancestor, or a pane in an occluded window tells Ghostty
+it is occluded and cancels scheduled refreshes. Its app mailbox still drains
+on every wakeup. Stopping those ticks can block replay IO and deadlock the
+next synchronous surface call during adoption.
+
+The wrapper coalesces explicit render requests, scroll input, and completed
+host-fed writes into one main-queue refresh per pending batch. It owns no
+repeating display-link subscription or one-second refresh tail. Ghostty core
+owns vsync and ordinary local-PTY output rendering. Resize and adoption keep
+their synchronous fresh-frame path and cancel redundant queued refreshes.
+
+Controllers must explicitly opt into raw HTTP byte-stream continuations.
+Their feed must retain parser state and insert no bytes between pages,
+including inside split UTF-8 and OSC/APC payloads larger than a page. Older
+Controllers keep boundary-safe pages because their feed may add its own
+synchronized-output brackets. Replay-start alignment still applies to rebased
+cursors. Long polls wait for deliverable progress, and the native Controller
+paces empty unchanged-cursor replies from older Hosts.
+
 ### Terminal links
 
 Both local PTY panes and retained Host-streamed panes handle Ghostty's URL,

--- a/docs/agents/serve.md
+++ b/docs/agents/serve.md
@@ -622,6 +622,24 @@ running. Scripted Link activation for the same provisioning lane is
 `unpeel link enroll <key>` (shared `unpeel_core::license` implementation
 with the interactive path — see `docs/agents/cli.md` for the invariants).
 
+### HTTP terminal output pagination
+
+Protocol 1.20 advertises `session.output.raw`. A Controller may request
+`GET /mobile/output?raw=1` only when it retains parser state and inserts no
+bytes between pages. Native negotiates that capability from bootstrap. iOS
+keeps the default UTF-8 and VT-safe boundaries because its feed inserts local
+synchronized-output brackets.
+
+Raw pages preserve byte-exact continuation through split scalars and control
+strings. Default pages withhold incomplete sequences; a sequence that cannot
+fit the requested limit returns an explicit error instead of unsafe partial
+data. Both modes respect the requested wire limit, capped at 8 MiB.
+
+Long polls wait for deliverable progress, not just journal growth. Quiet ticks
+check journal, retention, and manifest metadata; a bounded health recheck
+still detects process exit. The native Controller also paces empty replies
+with unchanged cursors from older Hosts.
+
 ### Change gates
 
 Serve lifecycle, protocol, or launch changes must run these gates serially

--- a/protocol/host-capabilities-v1.json
+++ b/protocol/host-capabilities-v1.json
@@ -2,13 +2,19 @@
   "schemaVersion": 1,
   "protocol": {
     "major": 1,
-    "minor": 19,
+    "minor": 20,
     "compatibility": {
       "major": "must-match",
       "minor": "additive",
       "unknownCapabilities": "ignore"
     },
     "history": [
+      {
+        "minor": 20,
+        "release": "0.6.0",
+        "summary": "Explicit raw=1 output continuation for Controllers that retain their parser and inject no bytes between pages. Default replies end at UTF-8 and VT ground boundaries; a sequence that cannot fit the requested limit returns an explicit error, bounded at 8 MiB.",
+        "capabilities": ["session.output.raw"]
+      },
       {
         "minor": 19,
         "release": "0.6.0",
@@ -241,6 +247,13 @@
       "id": "session.output.read",
       "method": "GET",
       "path": "/mobile/output",
+      "native": true,
+      "tui": true
+    },
+    {
+      "id": "session.output.raw",
+      "method": "GET",
+      "path": "/mobile/output?raw=1",
       "native": true,
       "tui": true
     },

--- a/protocol/host-conformance-v1.json
+++ b/protocol/host-conformance-v1.json
@@ -54,6 +54,13 @@
       }
     },
     {
+      "id": "output.raw.missing-session",
+      "method": "GET",
+      "path": "/mobile/output",
+      "query": {"raw": "1"},
+      "expected": {"native": 400, "tui": 400}
+    },
+    {
       "id": "metrics.missing-session",
       "method": "GET",
       "path": "/mobile/metrics",


### PR DESCRIPTION
## Summary

Hidden and idle terminals no longer keep a display-rate GPU pump. The scheduler coalesces explicit refreshes and stops redraw work for hidden, detached, or occluded surfaces while `ghostty_app_tick` continues on every wakeup.

Protocol 1.22 advertises `session.output.raw` so capable Controllers can page raw continuations. Installed iOS clients keep safe-boundary pages.

The independent Host-switch selection fix moved to #15 and has merged.

## Measurements

Same window (1728×1084), same attached OpenCode session, 18s `accumulatedGPUTime` on this M5 Pro:

| Build | UnpeelNative GPU (ms/s) | CPU (% of one core) |
| --- | ---: | ---: |
| 0.6.0 build 47 | 12.15 | 9.94 |
| This branch (Dev build 5) | 8.12 | 9.88 |

Process GPU is about 33% lower. CPU is unchanged. Whole-device GPU percentage stayed in the 50s on both runs and came from WindowServer, not Unpeel.

Hidden-wrapper probe on the same machine: 31.7 ms/s GPU down to 0 while parsing continued.

This is one pair. It does not reproduce the original M3 Pro 81 to 92% whole-GPU report.

## Compatibility

Rebased onto current `main` after 0.7.2. Protocol minor 22 has its own capability ledger entry and conformance fixture. Hidden-pane lifecycle coverage verifies callbacks continue without rendering.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- Rust workspace, attach, Apps, clippy, and portable-core suites
- Native, shared Swift, and iOS simulator suites
- Full PTY matrix: 607 passed
- Attach and browser end-to-end verification
- Release, runtime catalog, notices, links, and Python checks

## Residual

The memory teardown gate failed on the original patch and its base commit. Thresholds were not loosened.

The live Dev measurement predates the rebase. The reconciliation kept the scheduler and app-tick behavior unchanged.

## Related

Related: #9