### PR TITLE
muse-code: register unified MCP server in staged plugin

### DIFF
--- a/clients/shared/UnpeelShared/Sources/UnpeelShared/GeneratedRuntimeCatalog.swift
+++ b/clients/shared/UnpeelShared/Sources/UnpeelShared/GeneratedRuntimeCatalog.swift
@@ -710,7 +710,7 @@ public enum UnpeelRuntimeCatalog {
             anchorStartEventToOutput: true,
             attentionClearsOnOutput: true,
             distrustStopsWhileOutputGrows: false,
-            capabilities: [.lifecycleHooks, .resume, .restartAgent, .transcript, .notifyWhenDone],
+            capabilities: [.lifecycleHooks, .resume, .restartAgent, .mcpSessions, .mcpBrowser, .mcpComputer, .transcript, .notifyWhenDone],
             usageStores: [
                 UnpeelRuntimeUsageStore(
                     root: ".local/share/muse/sessions",

--- a/generated/GeneratedRuntimeCatalog.swift
+++ b/generated/GeneratedRuntimeCatalog.swift
@@ -710,7 +710,7 @@ public enum UnpeelRuntimeCatalog {
             anchorStartEventToOutput: true,
             attentionClearsOnOutput: true,
             distrustStopsWhileOutputGrows: false,
-            capabilities: [.lifecycleHooks, .resume, .restartAgent, .transcript, .notifyWhenDone],
+            capabilities: [.lifecycleHooks, .resume, .restartAgent, .mcpSessions, .mcpBrowser, .mcpComputer, .transcript, .notifyWhenDone],
             usageStores: [
                 UnpeelRuntimeUsageStore(
                     root: ".local/share/muse/sessions",

--- a/runtimes/muse-code/adapter/mod.rs
+++ b/runtimes/muse-code/adapter/mod.rs
@@ -33,6 +33,10 @@ fn configure_host_command(
     Ok(())
 }
 
+fn has_automatic_mcp_setup(_command: &str) -> bool {
+    true
+}
+
 pub(crate) const INTEGRATION: Integration = Integration::new(
     Some(setup::install_muse_hooks),
     Some(configure_host_command),
@@ -40,6 +44,7 @@ pub(crate) const INTEGRATION: Integration = Integration::new(
 // Muse 1.0.3 interrupts the foreground turn on ESC without emitting Stop.
 // https://dev.meta.ai/docs/muse-code/interactive#steering
 .with_escape_cancellation()
+.with_automatic_mcp_setup(has_automatic_mcp_setup)
 .with_resume_adapter(resume::ADAPTER);
 
 #[cfg(test)]

--- a/runtimes/muse-code/adapter/setup.rs
+++ b/runtimes/muse-code/adapter/setup.rs
@@ -61,6 +61,11 @@ pub(crate) fn muse_plugin_manifest_json() -> Result<String, String> {
             })
         })
         .collect();
+    // Static always-on entry (rewritten only when staged content changes):
+    // the unified server fail-closes per session grant, and Muse spawns MCP
+    // servers with a stripped env, so identity comes from process ancestry
+    // (mcp_host::self_session_id), like cursor-agent.
+    let exe = crate::session_host::resolve_current_executable()?;
     let manifest = json!({
         "schemaVersion": 1,
         "name": MUSE_PLUGIN_ID,
@@ -72,7 +77,7 @@ pub(crate) fn muse_plugin_manifest_json() -> Result<String, String> {
             "skills": [],
             "commands": [],
             "hooks": hooks,
-            "mcpServers": [],
+            "mcpServers": [{ "id": "unpeel", "command": [exe.to_string_lossy(), crate::mcp_host::MCP_HOST_ARG] }],
             "reminders": []
         }
     });

--- a/runtimes/muse-code/runtime.toml
+++ b/runtimes/muse-code/runtime.toml
@@ -7,7 +7,7 @@ adapter = "builtin:muse"
 legacy_order = 12
 platforms = ["macos", "linux"]
 supports_quick_launch = true
-capabilities = ["lifecycle_hooks", "resume", "restart_agent", "transcript", "notify_when_done"]
+capabilities = ["lifecycle_hooks", "resume", "restart_agent", "mcp_sessions", "mcp_browser", "mcp_computer", "transcript", "notify_when_done"]
 
 [display]
 tint = "#0082FB"

--- a/runtimes/setup_conformance_tests.rs
+++ b/runtimes/setup_conformance_tests.rs
@@ -1052,6 +1052,23 @@ mod tests {
     }
 
     #[test]
+    fn muse_plugin_manifest_registers_unified_mcp_server() {
+        let manifest: Value =
+            serde_json::from_str(&super::muse_plugin_manifest_json().expect("manifest"))
+                .expect("parse manifest");
+        let servers = manifest["capabilities"]["mcpServers"]
+            .as_array()
+            .expect("mcpServers array");
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0]["id"], "unpeel");
+        let command = servers[0]["command"]
+            .as_array()
+            .expect("command array");
+        assert_eq!(command.len(), 2);
+        assert_eq!(command[1], "__mcp__");
+    }
+
+    #[test]
     fn muse_hook_script_records_stop_but_not_session_start() {
         let session_dir = temp_path("muse-record-session");
         let stop_payload = json!({


### PR DESCRIPTION
Gives the Muse runtime the same MCP capabilities Codex/Cursor already have.

- runtime.toml: add mcp_sessions, mcp_browser, mcp_computer
- setup.rs: emit unified __mcp__ stdio entry in the generated plugin manifest (static always-on; the server fail-closes per session grant, and Muse spawns MCP servers with a stripped env so identity resolves via process ancestry, like cursor-agent)
- mod.rs: automatic MCP setup callback (satisfies the catalog consistency assert)
- conformance test for the manifest entry; regenerated client catalogs

Verified live against a real session: the exact manifest shape surfaces 7 unpeel tools (agents, apps, artifacts, browser, sessions, skills, workspace). unpeel-core suite: 850 pass; 1 pre-existing failure also fails on main (hookless_launch_keeps_mcp_identity).